### PR TITLE
Prepare FlexDoc 2.0 versions, publishing, and distribution docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
@@ -69,5 +69,8 @@ jobs:
 
       - name: Verify Java adapter packages renderer assets
         run: |
-          jar tf adapters/java-spring/target/flexdoc-spring-boot-starter-0.1.0-SNAPSHOT.jar | grep 'META-INF/flexdoc/flexdoc.standalone.js'
-          jar tf adapters/java-spring/target/flexdoc-spring-boot-starter-0.1.0-SNAPSHOT.jar | grep 'META-INF/flexdoc/flexdoc.standalone.css'
+          JAR=adapters/java-spring/target/flexdoc-spring-boot-starter-0.1.0.jar
+          jar tf "$JAR" | grep 'META-INF/flexdoc/flexdoc.standalone.js'
+          jar tf "$JAR" | grep 'META-INF/flexdoc/flexdoc.standalone.css'
+          test -s adapters/java-spring/target/flexdoc-spring-boot-starter-0.1.0-sources.jar
+          test -s adapters/java-spring/target/flexdoc-spring-boot-starter-0.1.0-javadoc.jar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: '20'
           cache: npm
 
       - name: Setup Java

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,8 @@ jobs:
           test -s packages/backend/dist/renderer/flexdoc.standalone.js
           test -s packages/backend/dist/renderer/flexdoc.standalone.css
 
-      - name: Test and package Java Spring adapter
-        run: mvn -f adapters/java-spring/pom.xml --batch-mode verify
+      - name: Test Java Spring adapter with release profile
+        run: mvn -f adapters/java-spring/pom.xml --batch-mode -Prelease -Dgpg.skip=true verify
 
       - name: Verify Java adapter packages renderer assets
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           cache: npm
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: '17'

--- a/.github/workflows/publish-backend.yml
+++ b/.github/workflows/publish-backend.yml
@@ -3,7 +3,6 @@ name: Publish Backend to npm Registry
 on:
   release:
     types: [published]
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -11,7 +10,7 @@ permissions:
 
 jobs:
   build-and-publish:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'js/v')
+    if: startsWith(github.event.release.tag_name, 'js/v')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -36,7 +35,6 @@ jobs:
         run: npm run build -w packages/backend
 
       - name: Verify JavaScript release tag matches package version
-        if: github.event_name == 'release'
         run: |
           VERSION=$(node -p "require('./packages/backend/package.json').version")
           test "${{ github.event.release.tag_name }}" = "js/v${VERSION}"

--- a/.github/workflows/publish-backend.yml
+++ b/.github/workflows/publish-backend.yml
@@ -16,15 +16,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Setup Node.js
+      - name: Setup build Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
-          registry-url: 'https://registry.npmjs.org/'
-          package-manager-cache: false
-
-      - name: Ensure trusted-publishing capable npm
-        run: npm install --global npm@^11.15.0
+          node-version: '20'
+          cache: npm
 
       - name: Install dependencies
         run: npm ci
@@ -48,6 +44,16 @@ jobs:
         run: |
           test -f packages/backend/dist/renderer/flexdoc.standalone.js
           test -f packages/backend/dist/renderer/flexdoc.standalone.css
+
+      - name: Setup publishing Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org/'
+          package-manager-cache: false
+
+      - name: Ensure trusted-publishing capable npm
+        run: npm install --global npm@^11.15.0
 
       - name: Inspect npm package contents
         run: npm pack --dry-run -w packages/backend

--- a/.github/workflows/publish-backend.yml
+++ b/.github/workflows/publish-backend.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   build-and-publish:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'js/v')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -34,11 +35,11 @@ jobs:
       - name: Build backend package
         run: npm run build -w packages/backend
 
-      - name: Verify release tag matches package version
+      - name: Verify JavaScript release tag matches package version
         if: github.event_name == 'release'
         run: |
           VERSION=$(node -p "require('./packages/backend/package.json').version")
-          test "${{ github.event.release.tag_name }}" = "v${VERSION}"
+          test "${{ github.event.release.tag_name }}" = "js/v${VERSION}"
 
       - name: Verify packaged renderer assets
         run: |

--- a/.github/workflows/publish-backend.yml
+++ b/.github/workflows/publish-backend.yml
@@ -2,30 +2,35 @@ name: Publish Backend to npm Registry
 
 on:
   release:
-    types: [created]
+    types: [published]
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to publish (e.g., patch, minor, major, or specific version)'
-        required: true
-        default: 'patch'
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org/'
+          package-manager-cache: false
+
+      - name: Ensure trusted-publishing capable npm
+        run: npm install --global npm@^11.15.0
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Build canonical client renderer
+        run: npm run build -w packages/client
 
       - name: Test backend package
         run: npm test -w packages/backend -- --runInBand
@@ -33,28 +38,19 @@ jobs:
       - name: Build backend package
         run: npm run build -w packages/backend
 
-      - name: Update package.json for npm registry
-        run: |
-          cd packages/backend
-          # Remove GitHub specific publishConfig if present
-          sed -i '/"publishConfig": {/,/}/d' package.json
-
-      - name: Version and publish (on manual trigger)
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          cd packages/backend
-          CURRENT_VERSION=$(node -p "require('./package.json').version")
-          if [ "$CURRENT_VERSION" != "${{ github.event.inputs.version }}" ]; then
-            npm version ${{ github.event.inputs.version }} --no-git-tag-version
-          fi
-          npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Publish on release
+      - name: Verify release tag matches package version
         if: github.event_name == 'release'
         run: |
-          cd packages/backend
-          npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          VERSION=$(node -p "require('./packages/backend/package.json').version")
+          test "${{ github.event.release.tag_name }}" = "v${VERSION}"
+
+      - name: Verify packaged renderer assets
+        run: |
+          test -f packages/backend/dist/assets/flexdoc.standalone.js
+          test -f packages/backend/dist/assets/flexdoc.standalone.css
+
+      - name: Inspect npm package contents
+        run: npm pack --dry-run -w packages/backend
+
+      - name: Publish backend through npm Trusted Publishing
+        run: npm publish -w packages/backend --access public

--- a/.github/workflows/publish-backend.yml
+++ b/.github/workflows/publish-backend.yml
@@ -46,8 +46,8 @@ jobs:
 
       - name: Verify packaged renderer assets
         run: |
-          test -f packages/backend/dist/assets/flexdoc.standalone.js
-          test -f packages/backend/dist/assets/flexdoc.standalone.css
+          test -f packages/backend/dist/renderer/flexdoc.standalone.js
+          test -f packages/backend/dist/renderer/flexdoc.standalone.css
 
       - name: Inspect npm package contents
         run: npm pack --dry-run -w packages/backend

--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -2,29 +2,29 @@ name: Publish Client to npm Registry
 
 on:
   release:
-    types: [created]
+    types: [published]
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to publish (e.g., patch, minor, major, or specific version)'
-        required: true
-        default: 'patch'
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org/'
+          package-manager-cache: false
+
+      - name: Ensure trusted-publishing capable npm
+        run: npm install --global npm@^11.15.0
 
       - name: Install dependencies
         run: npm ci
@@ -35,13 +35,23 @@ jobs:
       - name: Build client package
         run: npm run build -w packages/client
 
+      - name: Verify release tag matches package version
+        if: github.event_name == 'release'
+        run: |
+          VERSION=$(node -p "require('./packages/client/package.json').version")
+          test "${{ github.event.release.tag_name }}" = "v${VERSION}"
+
+      - name: Inspect npm package contents
+        run: npm pack --dry-run -w packages/client
+
       - name: Assemble language-neutral renderer bundle
         run: |
           mkdir -p renderer-release
           cp packages/client/dist/standalone/flexdoc.standalone.js renderer-release/
           cp packages/client/dist/standalone/flexdoc.standalone.css renderer-release/
           cp packages/renderer-contract/flexdoc-renderer.schema.json renderer-release/
-          printf '%s\n' '{"contractVersion":"1"}' > renderer-release/manifest.json
+          VERSION=$(node -p "require('./packages/client/package.json').version")
+          printf '{"contractVersion":"1","rendererVersion":"%s"}\n' "$VERSION" > renderer-release/manifest.json
           tar -czf flexdoc-renderer.tar.gz -C renderer-release .
 
       - name: Upload renderer workflow artifact
@@ -57,35 +67,5 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Update package.json for npm registry
-        run: |
-          cd packages/client
-          sed -i '/"publishConfig": {/,/}/d' package.json
-          node -e "
-            const pkg = require('./package.json');
-            pkg.main = './dist/flexdoc.umd.cjs';
-            pkg.module = './dist/flexdoc.es.js';
-            pkg.types = './dist/index.d.ts';
-            pkg.files = ['dist', 'README.md'];
-            require('fs').writeFileSync('./package.json', JSON.stringify(pkg, null, 2));
-          "
-
-      - name: Version and publish (on manual trigger)
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          cd packages/client
-          CURRENT_VERSION=$(node -p "require('./package.json').version")
-          if [ "$CURRENT_VERSION" != "${{ github.event.inputs.version }}" ]; then
-            npm version ${{ github.event.inputs.version }} --no-git-tag-version
-          fi
-          npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Publish on release
-        if: github.event_name == 'release'
-        run: |
-          cd packages/client
-          npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish client through npm Trusted Publishing
+        run: npm publish -w packages/client --access public

--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -16,15 +16,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Setup Node.js
+      - name: Setup build Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
-          registry-url: 'https://registry.npmjs.org/'
-          package-manager-cache: false
-
-      - name: Ensure trusted-publishing capable npm
-        run: npm install --global npm@^11.15.0
+          node-version: '20'
+          cache: npm
 
       - name: Install dependencies
         run: npm ci
@@ -40,9 +36,6 @@ jobs:
         run: |
           VERSION=$(node -p "require('./packages/client/package.json').version")
           test "${{ github.event.release.tag_name }}" = "v${VERSION}"
-
-      - name: Inspect npm package contents
-        run: npm pack --dry-run -w packages/client
 
       - name: Assemble language-neutral renderer bundle
         run: |
@@ -66,6 +59,19 @@ jobs:
         run: gh release upload "${{ github.event.release.tag_name }}" flexdoc-renderer.tar.gz --clobber
         env:
           GH_TOKEN: ${{ github.token }}
+
+      - name: Setup publishing Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org/'
+          package-manager-cache: false
+
+      - name: Ensure trusted-publishing capable npm
+        run: npm install --global npm@^11.15.0
+
+      - name: Inspect npm package contents
+        run: npm pack --dry-run -w packages/client
 
       - name: Publish client through npm Trusted Publishing
         run: npm publish -w packages/client --access public

--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   build-and-publish:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'js/v')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -31,11 +32,11 @@ jobs:
       - name: Build client package
         run: npm run build -w packages/client
 
-      - name: Verify release tag matches package version
+      - name: Verify JavaScript release tag matches package version
         if: github.event_name == 'release'
         run: |
           VERSION=$(node -p "require('./packages/client/package.json').version")
-          test "${{ github.event.release.tag_name }}" = "v${VERSION}"
+          test "${{ github.event.release.tag_name }}" = "js/v${VERSION}"
 
       - name: Assemble language-neutral renderer bundle
         run: |

--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -3,7 +3,6 @@ name: Publish Client to npm Registry
 on:
   release:
     types: [published]
-  workflow_dispatch:
 
 permissions:
   contents: write
@@ -11,7 +10,7 @@ permissions:
 
 jobs:
   build-and-publish:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'js/v')
+    if: startsWith(github.event.release.tag_name, 'js/v')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -33,7 +32,6 @@ jobs:
         run: npm run build -w packages/client
 
       - name: Verify JavaScript release tag matches package version
-        if: github.event_name == 'release'
         run: |
           VERSION=$(node -p "require('./packages/client/package.json').version")
           test "${{ github.event.release.tag_name }}" = "js/v${VERSION}"
@@ -56,7 +54,6 @@ jobs:
           if-no-files-found: error
 
       - name: Attach renderer bundle to GitHub release
-        if: github.event_name == 'release'
         run: gh release upload "${{ github.event.release.tag_name }}" flexdoc-renderer.tar.gz --clobber
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/publish-java.yml
+++ b/.github/workflows/publish-java.yml
@@ -22,17 +22,15 @@ jobs:
           node-version: '20'
           cache: npm
 
-      - name: Setup Java, Maven Central credentials, and GPG key
-        uses: actions/setup-java@v5
+      - name: Setup Java and Maven Central credentials
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: '17'
           cache: maven
           server-id: central
-          server-username: MAVEN_CENTRAL_USERNAME
-          server-password: MAVEN_CENTRAL_PASSWORD
-          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+          server-username-env-var: MAVEN_CENTRAL_USERNAME
+          server-password-env-var: MAVEN_CENTRAL_PASSWORD
 
       - name: Install JavaScript dependencies
         run: npm ci
@@ -52,8 +50,9 @@ jobs:
           test -s packages/client/dist/standalone/flexdoc.standalone.css
 
       - name: Sign and publish Spring adapter to Maven Central
-        run: mvn -f adapters/java-spring/pom.xml --batch-mode -Prelease deploy
+        run: mvn -f adapters/java-spring/pom.xml --batch-mode -Prelease -Dgpg.signer=bc deploy
         env:
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          MAVEN_GPG_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/.github/workflows/publish-java.yml
+++ b/.github/workflows/publish-java.yml
@@ -1,0 +1,59 @@
+name: Publish Spring Adapter to Maven Central
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-sign-and-publish:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'java/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Setup Java, Maven Central credentials, and GPG key
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+          server-id: central
+          server-username: MAVEN_CENTRAL_USERNAME
+          server-password: MAVEN_CENTRAL_PASSWORD
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Install JavaScript dependencies
+        run: npm ci
+
+      - name: Build canonical standalone renderer
+        run: npm run build:client
+
+      - name: Verify Java release tag matches adapter version
+        if: github.event_name == 'release'
+        run: |
+          VERSION=$(mvn -q -f adapters/java-spring/pom.xml help:evaluate -Dexpression=project.version -DforceStdout)
+          test "${{ github.event.release.tag_name }}" = "java/v${VERSION}"
+
+      - name: Verify renderer assets before publication
+        run: |
+          test -s packages/client/dist/standalone/flexdoc.standalone.js
+          test -s packages/client/dist/standalone/flexdoc.standalone.css
+
+      - name: Sign and publish Spring adapter to Maven Central
+        run: mvn -f adapters/java-spring/pom.xml --batch-mode -Prelease deploy
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/.github/workflows/publish-java.yml
+++ b/.github/workflows/publish-java.yml
@@ -3,14 +3,13 @@ name: Publish Spring Adapter to Maven Central
 on:
   release:
     types: [published]
-  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
   build-sign-and-publish:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'java/v')
+    if: startsWith(github.event.release.tag_name, 'java/v')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -39,7 +38,6 @@ jobs:
         run: npm run build:client
 
       - name: Verify Java release tag matches adapter version
-        if: github.event_name == 'release'
         run: |
           VERSION=$(mvn -q -f adapters/java-spring/pom.xml help:evaluate -Dexpression=project.version -DforceStdout)
           test "${{ github.event.release.tag_name }}" = "java/v${VERSION}"

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,12 @@ dist
 dist-ssr
 *.local
 
+# Local environment and credentials
+.env
+.env.*
+!.env.example
+!.env.*.example
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
@@ -22,7 +28,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
-.env
 
 # Coverage directories
 coverage

--- a/README.md
+++ b/README.md
@@ -1,361 +1,172 @@
-# FlexDoc - OpenAPI Documentation Generator
+# FlexDoc
 
-FlexDoc is a beautiful, highly customizable OpenAPI documentation generator that can be easily integrated into backend applications. It provides a modern, interactive interface for API documentation with advanced features and customization options.
+FlexDoc is an open-source, self-hosted OpenAPI documentation renderer and API explorer. It ships one canonical browser renderer and thin framework adapters, so React, Node backends, and Spring Boot all use the same OpenAPI behavior and UI.
 
-## Features
+FlexDoc is designed to live with your API: no FlexDoc account, hosted dashboard, telemetry service, or runtime CDN is required.
 
-- 🎨 **Beautiful UI**: Modern, responsive design with smooth animations and micro-interactions
-- 📱 **Mobile-First**: Fully responsive design that works on all devices
-- 🎯 **Interactive**: Live API explorer with request/response examples
-- 🔍 **Advanced Search**: Powerful search and filtering capabilities
-- 🎨 **Customizable**: Extensive theming and styling options
-- 🔒 **Authentication**: Secure your documentation with Basic or Bearer token authentication
-- ⚡ **Fast**: Optimized performance with lazy loading and efficient rendering
-- 🔧 **Easy Integration**: Simple setup for NestJS and other frameworks
-- 📖 **OpenAPI 3.0**: Full support for OpenAPI 3.0 specifications
+## What is in FlexDoc 2.0
 
-## Quick Start
+- OpenAPI 3.0/3.1 normalization and reference resolution, including relative external references
+- responsive API reference UI with search and deep links
+- interactive **Try It** request execution and response inspection
+- server selection and OpenAPI server variables
+- API key, Basic, Bearer, OAuth2/OpenID bearer request authentication
+- OpenAPI parameter serialization including deepObject, matrix, label, pipe/space-delimited and explode semantics
+- JSON, form-urlencoded and multipart request bodies
+- code examples for cURL, JavaScript, Python, Go and Java generated from the same canonical request model
+- schema composition and recursive-reference rendering
+- light/dark theming and renderer options
+- standalone browser JS/CSS artifacts with no runtime CDN dependency
+- Express, Fastify and NestJS integrations
+- Spring Boot adapter that packages the same canonical renderer assets
 
-### React Component (Standalone)
+Browser-side loading of cross-origin external OpenAPI references is subject to the target server's CORS policy. Server-side/CLI bundling can avoid that constraint.
+
+## Packages
+
+| Package | Version | Purpose |
+| --- | --- | --- |
+| `@bluejeans/flexdoc-client` | `2.0.0` | React components plus the canonical standalone renderer |
+| `@bluejeans/flexdoc-backend` | `2.0.0` | Thin Express, Fastify and NestJS integrations |
+| `io.github.bluejeans117.flexdoc:flexdoc-spring-boot-starter` | `0.1.0` | Spring Boot adapter; Maven Central publication is prepared separately |
+
+Language adapters have independent ecosystem versions. Compatibility is governed by the renderer contract rather than forcing npm, Maven, PyPI, crates.io and Go modules to share one version number. See [Distribution and versioning](./docs/distribution.md).
+
+## React
 
 ```bash
-npm install @bluejeans/flexdoc
+npm install @bluejeans/flexdoc-client@^2
 ```
 
 ```tsx
-import { FlexDoc } from '@bluejeans/flexdoc';
-import { openApiSpec } from './your-spec';
+import { FlexDoc } from '@bluejeans/flexdoc-client';
+import '@bluejeans/flexdoc-client/styles.css';
 
-function App() {
-  return (
-    <FlexDoc
-      spec={openApiSpec}
-      theme='light'
-      customStyles={{ fontFamily: 'Inter' }}
-    />
-  );
+export function Docs({ spec }) {
+  return <FlexDoc spec={spec} theme="light" tryItEnabled />;
 }
 ```
 
-### NestJS Integration
+The package also exports the standalone renderer used by non-React adapters.
+
+## Express
 
 ```bash
-npm install @bluejeans/flexdoc-backend
+npm install @bluejeans/flexdoc-backend@^2
 ```
 
-```typescript
-// app.module.ts
-import { Module } from '@nestjs/common';
-import { FlexDocModule } from '@bluejeans/flexdoc-backend';
-
-@Module({
-  imports: [
-    // Your other modules...
-    FlexDocModule.forRoot({
-      path: 'api-docs',
-      options: {
-        title: 'My API Documentation',
-        hideHostname: true,
-        pathInMiddlePanel: true,
-        // Enable authentication (optional)
-        auth: {
-          type: 'basic', // or 'bearer'
-          secretKey: process.env.FLEXDOC_SECRET_KEY || 'your-strong-secret-key',
-        },
-      },
-    }),
-  ],
-})
-export class AppModule {}
-```
-
-### Express Integration
-
-```typescript
+```ts
 import express from 'express';
-import { setupFlexDoc } from '@bluejeans/flexdoc-backend';
+import { setupExpressFlexDoc } from '@bluejeans/flexdoc-backend';
 
 const app = express();
 
-// Your other routes and middleware...
-
-// Set up FlexDoc
-setupFlexDoc(app, {
-  path: 'api-docs',
-  options: {
-    title: 'My API Documentation',
-    hideHostname: true,
-    pathInMiddlePanel: true,
-    // Enable authentication (optional)
-    auth: {
-      type: 'basic', // or 'bearer'
-      secretKey: process.env.FLEXDOC_SECRET_KEY || 'your-strong-secret-key',
-    },
-  },
+setupExpressFlexDoc(app, {
+  path: '/docs',
+  specUrl: 'https://example.com/openapi.json',
+  options: { title: 'Example API' },
 });
 
-app.listen(3000, () => {
-  console.log('Server running on http://localhost:3000');
+app.listen(3000);
+```
+
+`setupFlexDoc` remains available for the existing Express integration. Native `setupFastifyFlexDoc` and `setupNestFlexDoc` helpers are also exported.
+
+## NestJS
+
+If you use `@nestjs/swagger`, FlexDoc can generate the document through Nest's `SwaggerModule.createDocument` and then serve it with the same renderer:
+
+```ts
+import { setupNestFlexDoc } from '@bluejeans/flexdoc-backend';
+
+await setupNestFlexDoc(app, {
+  path: '/docs',
+  options: { title: 'My API' },
 });
 ```
 
-## Authentication
+`@nestjs/swagger` is optional and is only required when using the automatic Nest document helper.
 
-FlexDoc supports two authentication methods to secure your API documentation:
+## Spring Boot
 
-### Basic Authentication
+The Java adapter is currently built from this repository and is prepared for Maven Central publication. Once published, applications using springdoc can use `/v3/api-docs` without custom spec plumbing:
 
-```typescript
-// In your configuration
-options: {
-  auth: {
-    type: 'basic',
-    secretKey: process.env.FLEXDOC_SECRET_KEY
-  }
-}
+```yaml
+flexdoc:
+  path: /docs
+  spec-url: /v3/api-docs
+  title: My API
+  theme: dark
 ```
 
-Generate credentials for users:
+See [`adapters/java-spring`](./adapters/java-spring/README.md) for the complete integration and current publication status.
+
+## Architecture
+
+FlexDoc deliberately has one renderer implementation:
+
+```text
+OpenAPI document
+      |
+      v
+normalization / resolution
+      |
+      v
+canonical renderer + request model
+      |
+      +--> React
+      +--> standalone static assets
+      +--> Node framework adapters
+      +--> Spring Boot adapter
+      +--> future Python / Rust / Go adapters
+```
+
+Framework adapters obtain or generate the OpenAPI document, serve a small host page, and serve version-matched renderer assets. They do not reimplement parsing, request construction, code generation, Try It, schemas, or theming.
+
+The language-neutral contract is in [`packages/renderer-contract`](./packages/renderer-contract/).
+
+## Development
 
 ```bash
-# Using the CLI tool
-npx ts-node generate-auth.ts basic --username admin --secret your-strong-secret-key
+npm ci
+npm test --workspace=@bluejeans/flexdoc-client
+npm run build --workspace=@bluejeans/flexdoc-client
+npm test --workspace=@bluejeans/flexdoc-backend
+npm run build --workspace=@bluejeans/flexdoc-backend
+mvn -f adapters/java-spring/pom.xml verify
 ```
 
-### Bearer Authentication (JWT)
+CI additionally verifies that backend and Java artifacts contain the canonical standalone renderer assets.
 
-```typescript
-// In your configuration
-options: {
-  auth: {
-    type: 'bearer',
-    secretKey: process.env.FLEXDOC_SECRET_KEY
-  }
-}
-```
+## Release and distribution
 
-Generate JWT tokens:
+The JavaScript packages are released as a coordinated `2.x` line. New language adapters start with their own ecosystem-native versions and declare/document renderer-contract compatibility.
 
-```bash
-# Using the CLI tool
-npx ts-node generate-auth.ts bearer --expiry 30 --secret your-strong-secret-key
-```
+Publication credentials must never be committed to this repository. npm, Maven Central, PyPI and other registry credentials/trusted-publishing configuration belong in the registry and GitHub Actions environment configuration.
 
-For more details, see the [Authentication Guide](./packages/backend/docs/authentication.md).
-
-## Configuration Options
-
-### FlexDocOptions
-
-```typescript
-interface FlexDocOptions {
-  title?: string; // Page title
-  description?: string; // Page description
-  theme?: 'light' | 'dark' | ThemeOptions; // Color theme
-  customCss?: string; // Custom CSS styles
-  customJs?: string; // Custom JavaScript
-  favicon?: string; // Custom favicon URL
-  logo?: string; // Custom logo URL
-  hideHostname?: boolean; // Hide hostname in API endpoints
-  pathInMiddlePanel?: boolean; // Show path in middle panel
-
-  // Authentication
-  auth?: {
-    type: 'basic' | 'bearer';
-    secretKey: string;
-  };
-
-  // Advanced theming
-  theme_?: {
-    colors?: {
-      primary?: string; // Primary brand color
-      secondary?: string; // Secondary color
-      accent?: string; // Accent color
-      background?: string; // Background color
-      surface?: string; // Surface color
-      text?: string; // Text color
-      textSecondary?: string; // Secondary text color
-      border?: string; // Border color
-    };
-    typography?: {
-      fontSize?: string; // Base font size
-      fontFamily?: string; // Font family
-      lineHeight?: string; // Line height
-    };
-    spacing?: {
-      unit?: number; // Base spacing unit
-    };
-  };
-}
-```
-
-For a complete list of configuration options, see the [Configuration Guide](./docs/configuration.md).
-
-## Examples
-
-### Basic Usage
-
-```typescript
-FlexDocModule.forRoot({
-  path: 'api-docs',
-  options: {
-    title: 'Pet Store API',
-    description: 'Beautiful API documentation',
-    theme: 'light',
-  },
-});
-```
-
-### Custom Theming
-
-```typescript
-FlexDocModule.forRoot({
-  path: 'api-docs',
-  options: {
-    title: 'My API',
-    theme: {
-      primaryColor: '#6366f1',
-      secondaryColor: '#10b981',
-      backgroundColor: '#ffffff',
-      textColor: '#333333',
-    },
-    customCss: `
-      .flexdoc-container {
-        --border-radius: 12px;
-      }
-      .method-badge {
-        border-radius: var(--border-radius);
-      }
-    `,
-  },
-});
-```
-
-### Secured Documentation with Authentication
-
-```typescript
-FlexDocModule.forRoot({
-  path: 'api-docs',
-  options: {
-    title: 'Internal API Documentation',
-    theme: 'dark',
-    auth: {
-      type: 'basic', // or 'bearer'
-      secretKey: process.env.FLEXDOC_SECRET_KEY,
-    },
-  },
-});
-```
-
-### Multiple Documentation Sites
-
-```typescript
-// Public API docs
-FlexDocModule.forRoot({
-  path: 'public-docs',
-  options: { title: 'Public API' },
-});
-
-// Internal API docs (with authentication)
-FlexDocModule.forRoot({
-  path: 'internal-docs',
-  options: {
-    title: 'Internal API',
-    theme: 'dark',
-    auth: {
-      type: 'basic',
-      secretKey: process.env.FLEXDOC_SECRET_KEY,
-    },
-  },
-});
-```
-
-## Running the Example
-
-1. Clone the repository
-2. Install dependencies:
-   ```bash
-   npm install
-   ```
-3. Navigate to the NestJS example:
-   ```bash
-   cd packages/examples/nestjs
-   npm run start:dev
-   ```
-4. Open your browser:
-   - FlexDoc: http://localhost:3000/api-docs
-
-## Comparison with Other Tools
-
-| Feature              | FlexDoc | Redoc | Swagger UI |
-| -------------------- | ------- | ----- | ---------- |
-| Modern UI            | ✅      | ✅    | ❌         |
-| Mobile Responsive    | ✅      | ✅    | ⚠️         |
-| Interactive Examples | ✅      | ❌    | ✅         |
-| Advanced Search      | ✅      | ⚠️    | ❌         |
-| Custom Theming       | ✅      | ⚠️    | ⚠️         |
-| Authentication       | ✅      | ❌    | ⚠️         |
-| Performance          | ✅      | ✅    | ⚠️         |
-| Easy Integration     | ✅      | ✅    | ✅         |
-
-## Browser Support
-
-- Chrome 90+
-- Firefox 88+
-- Safari 14+
-- Edge 90+
-
-## Contributing
-
-We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details.
-
-## Testing
-
-FlexDoc uses Jest for testing both the client and backend packages. Each package has its own test configuration and coverage reports.
-
-### Client Tests
-
-```bash
-cd packages/client
-npm test
-```
-
-To generate coverage reports:
-
-```bash
-cd packages/client
-npm run test:coverage
-```
-
-### Backend Tests
-
-```bash
-cd packages/backend
-npm test
-```
-
-To generate coverage reports:
-
-```bash
-cd packages/backend
-npm run test:coverage
-```
-
-## License
-
-MIT License - see [LICENSE](LICENSE) file for details.
-
-## Support
-
-- 📖 [Documentation](https://bluejeans117.github.io/flexdoc)
-- 🐛 [Issue Tracker](https://github.com/bluejeans117/flexdoc/issues)
-- 📧 [Email Support](mailto:vishnurajesh45@gmail.com)
+See [Distribution and versioning](./docs/distribution.md) for the release model, Maven Central setup, and the planned Python/Rust/Go distribution paths.
 
 ## Documentation
 
-- [Getting Started](./docs/getting-started.md)
-- [Configuration Options](./docs/configuration.md)
-- [Theming Guide](./docs/theming.md)
-- [Authentication](./packages/backend/docs/authentication.md)
-- [API Reference](./docs/api-reference.md)
-- [Examples](./packages/examples)
+- [Getting started](./docs/getting-started.md)
+- [Configuration](./docs/configuration.md)
+- [Framework adapters](./docs/framework-adapters.md)
+- [Renderer product/architecture](./docs/renderer-product.md)
+- [Distribution and versioning](./docs/distribution.md)
+- [Theming](./docs/theming.md)
+- [API reference](./docs/api-reference.md)
+
+## Security and self-hosting
+
+FlexDoc renderer assets are packaged with the integration rather than fetched from a third-party CDN. Documentation-route Basic/Bearer credentials are validated on the server and are not serialized into the browser configuration.
+
+Do not commit `.env` files, publishing tokens, signing keys, API credentials, or production secrets. Local `.env*` files are ignored except explicitly named example files.
+
+## License
+
+FlexDoc is licensed under **AGPL-3.0-or-later**. See [LICENSE](./LICENSE).
+
+## Project
+
+- Documentation/demo: https://bluejeans117.github.io/flexdoc
+- Issues: https://github.com/bluejeans117/flexdoc/issues

--- a/adapters/java-spring/README.md
+++ b/adapters/java-spring/README.md
@@ -2,6 +2,20 @@
 
 Java/Spring adapter for the canonical FlexDoc browser renderer. The JAR packages the same version-matched `flexdoc.standalone.js` and `flexdoc.standalone.css` used by the Node integrations; it does not implement a Java-specific OpenAPI renderer.
 
+Current source version: `0.1.0`. It targets renderer contract v1 / FlexDoc renderer 2.x.
+
+> The artifact is prepared for Maven Central publication but should not be described as available from Central until the first release has actually been published and verified.
+
+Planned coordinates:
+
+```xml
+<dependency>
+  <groupId>io.github.bluejeans117.flexdoc</groupId>
+  <artifactId>flexdoc-spring-boot-starter</artifactId>
+  <version>0.1.0</version>
+</dependency>
+```
+
 ## Spring Boot + springdoc
 
 If your application already exposes the standard springdoc endpoint at `/v3/api-docs`, the default configuration is enough. Adding the starter exposes FlexDoc at `/docs`; the browser loads `/v3/api-docs` from the same origin and the shared renderer handles references, Try It, schemas and code examples.
@@ -43,11 +57,14 @@ The adapter intentionally owns only framework plumbing: obtaining the OpenAPI do
 
 ## Building in this repository
 
-Build the standalone renderer first, then package the JAR:
+Build the standalone renderer first, then package and verify the JAR:
 
 ```bash
 npm run build:client
 mvn -f adapters/java-spring/pom.xml verify
+jar tf adapters/java-spring/target/flexdoc-spring-boot-starter-0.1.0.jar | grep META-INF/flexdoc
 ```
 
-CI verifies the Spring tests and that the resulting JAR contains both version-matched renderer assets.
+The release build attaches source and Javadoc JARs. CI should also verify that the resulting JAR contains both canonical renderer assets before publication.
+
+For Central setup and the versioning model used by future language adapters, see [`docs/distribution.md`](../../docs/distribution.md).

--- a/adapters/java-spring/pom.xml
+++ b/adapters/java-spring/pom.xml
@@ -111,4 +111,37 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.2.7</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals><goal>sign</goal></goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.11.0</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
+              <waitUntil>published</waitUntil>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/adapters/java-spring/pom.xml
+++ b/adapters/java-spring/pom.xml
@@ -3,9 +3,31 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.bluejeans117.flexdoc</groupId>
   <artifactId>flexdoc-spring-boot-starter</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.1.0</version>
   <name>FlexDoc Spring Boot Starter</name>
-  <description>Self-hosted FlexDoc adapter for Spring Boot</description>
+  <description>Spring Boot adapter for the self-hosted FlexDoc OpenAPI renderer and API explorer</description>
+  <url>https://github.com/bluejeans117/flexdoc</url>
+
+  <licenses>
+    <license>
+      <name>GNU Affero General Public License v3.0 or later</name>
+      <url>https://www.gnu.org/licenses/agpl-3.0.html</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <name>Vishnu R</name>
+      <url>https://github.com/bluejeans117</url>
+    </developer>
+  </developers>
+  <scm>
+    <connection>scm:git:https://github.com/bluejeans117/flexdoc.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/bluejeans117/flexdoc.git</developerConnection>
+    <url>https://github.com/bluejeans117/flexdoc</url>
+    <tag>HEAD</tag>
+  </scm>
+
   <properties>
     <java.version>17</java.version>
     <spring-boot.version>3.3.0</spring-boot.version>
@@ -64,6 +86,28 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.2.5</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.3.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals><goal>jar-no-fork</goal></goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.8.0</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals><goal>jar</goal></goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -19,6 +19,15 @@ Do not synchronize versions across registries merely for aesthetics. Existing np
 
 A breaking renderer-contract change requires a new contract major. An adapter can evolve independently while it continues to consume the same contract.
 
+## Release tags
+
+Registry releases are intentionally scoped by ecosystem so independent adapter versions do not trigger unrelated publishers:
+
+- `js/v<version>` publishes the coordinated npm client/backend release;
+- `java/v<version>` publishes the Spring Boot adapter to Maven Central.
+
+Future adapters should use an equivalent ecosystem-specific tag family when they gain automated publishing.
+
 ## npm
 
 The npm packages are public scoped packages:
@@ -28,13 +37,15 @@ The npm packages are public scoped packages:
 
 For the consolidated renderer architecture, both packages move to `2.0.0`.
 
-Recommended release policy:
+The release workflows use npm Trusted Publishing through GitHub OIDC. No long-lived `NPM_TOKEN` is required. The trusted-publisher relationship on npmjs.com must point to the exact GitHub repository and workflow filename for each package.
+
+Release policy:
 
 1. merge only after client/backend tests, standalone build checks, contract validation, backend asset checks and Java verification are green;
-2. create an immutable Git tag/GitHub Release for the version;
-3. publish with npm Trusted Publishing (OIDC) where supported, rather than storing a long-lived npm automation token;
-4. publish with provenance enabled;
-5. inspect the packed artifact (`npm pack --dry-run` or equivalent) before publishing;
+2. create an immutable `js/v<version>` Git tag/GitHub Release;
+3. let the client and backend workflows validate that the tag matches the committed package version;
+4. inspect the packed artifact before publication;
+5. publish using npm Trusted Publishing;
 6. never rewrite a registry version. Fixes receive a new patch version.
 
 The two npm packages should remain on the same 2.x version for now because the backend vendors the canonical client renderer and coordinated versions make that relationship obvious.
@@ -49,19 +60,26 @@ io.github.bluejeans117.flexdoc:flexdoc-spring-boot-starter:0.1.0
 
 The Maven module contains the canonical renderer JS/CSS under `META-INF/flexdoc` and serves those local assets at runtime. It does not contain an alternate Java renderer.
 
-The POM includes the project URL, AGPL license, developer/SCM metadata, sources artifact and Javadocs artifact needed for a normal Central release. Registry/account configuration and signing/publishing credentials are intentionally not committed.
+The POM includes the project URL, AGPL license, developer/SCM metadata, sources artifact and Javadocs artifact required for a normal Central release. Its `release` Maven profile adds GPG signing and Sonatype's Central Publishing Maven Plugin. The Central plugin is configured for automatic publication and waits until Central reports the deployment as published.
 
-Before the first Central publication:
+The GitHub release workflow imports the signing key and configures Maven Central authentication from repository secrets. Secret values must never be committed. The expected GitHub Actions secret names are:
 
-1. create/sign in to a Maven Central Portal account;
-2. verify ownership of the `io.github.bluejeans117` namespace through the supported GitHub verification flow;
-3. configure the repository's publishing identity/credentials in GitHub Actions or the Central-supported publishing mechanism;
-4. configure artifact signing according to Central's current requirements;
-5. build the canonical standalone renderer before Maven packaging;
-6. run `mvn -f adapters/java-spring/pom.xml verify` and inspect the JAR for both renderer assets;
-7. publish `0.1.0` and verify its POM, sources, Javadocs and runtime assets from Central before announcing it in the main README.
+- `MAVEN_CENTRAL_USERNAME`
+- `MAVEN_CENTRAL_PASSWORD`
+- `MAVEN_GPG_PRIVATE_KEY`
+- `MAVEN_GPG_PASSPHRASE`
 
-The documentation must say “prepared for Maven Central publication” until the artifact can actually be resolved from Central.
+For a Java release:
+
+1. ensure the `io.github.bluejeans117` namespace is verified in Central Portal;
+2. ensure the Central user token and signing-key secrets are configured in GitHub Actions;
+3. build and validate the canonical renderer and Java release profile in CI;
+4. create an immutable `java/v<version>` Git tag/GitHub Release;
+5. let the workflow verify the tag against `project.version`;
+6. let Maven sign the POM, main JAR, sources JAR and Javadocs JAR and deploy them through the Central Portal plugin;
+7. confirm the workflow reaches Central's `published` state before announcing the artifact as generally available.
+
+The documentation must say “prepared/configured for Maven Central publication” until the artifact can actually be resolved from Central.
 
 ## Python / PyPI
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -1,0 +1,109 @@
+# Distribution and versioning
+
+FlexDoc uses one canonical browser renderer and thin ecosystem adapters. Distribution should preserve that architecture: a Java, Python, Rust, or Go integration packages/serves the version-matched renderer rather than implementing its own OpenAPI renderer.
+
+## Version model
+
+The renderer contract is the compatibility boundary between the shared browser product and language adapters.
+
+| Artifact | Release line | Compatibility |
+| --- | --- | --- |
+| `@bluejeans/flexdoc-client` | `2.x` | canonical renderer; renderer contract v1 |
+| `@bluejeans/flexdoc-backend` | `2.x` | packages the matching 2.x standalone renderer; contract v1 |
+| Spring Boot starter | `0.1.x` initially | renderer contract v1 / FlexDoc renderer 2.x |
+| Python adapter | future independent version | declare supported renderer contract |
+| Rust adapter | future independent version | declare supported renderer contract |
+| Go adapter | future independent module version | declare supported renderer contract |
+
+Do not synchronize versions across registries merely for aesthetics. Existing npm packages have release history, while a new Maven artifact does not. Instead, CI and package documentation must make renderer-contract compatibility explicit.
+
+A breaking renderer-contract change requires a new contract major. An adapter can evolve independently while it continues to consume the same contract.
+
+## npm
+
+The npm packages are public scoped packages:
+
+- `@bluejeans/flexdoc-client`
+- `@bluejeans/flexdoc-backend`
+
+For the consolidated renderer architecture, both packages move to `2.0.0`.
+
+Recommended release policy:
+
+1. merge only after client/backend tests, standalone build checks, contract validation, backend asset checks and Java verification are green;
+2. create an immutable Git tag/GitHub Release for the version;
+3. publish with npm Trusted Publishing (OIDC) where supported, rather than storing a long-lived npm automation token;
+4. publish with provenance enabled;
+5. inspect the packed artifact (`npm pack --dry-run` or equivalent) before publishing;
+6. never rewrite a registry version. Fixes receive a new patch version.
+
+The two npm packages should remain on the same 2.x version for now because the backend vendors the canonical client renderer and coordinated versions make that relationship obvious.
+
+## Maven Central / Spring Boot
+
+Coordinates:
+
+```text
+io.github.bluejeans117.flexdoc:flexdoc-spring-boot-starter:0.1.0
+```
+
+The Maven module contains the canonical renderer JS/CSS under `META-INF/flexdoc` and serves those local assets at runtime. It does not contain an alternate Java renderer.
+
+The POM includes the project URL, AGPL license, developer/SCM metadata, sources artifact and Javadocs artifact needed for a normal Central release. Registry/account configuration and signing/publishing credentials are intentionally not committed.
+
+Before the first Central publication:
+
+1. create/sign in to a Maven Central Portal account;
+2. verify ownership of the `io.github.bluejeans117` namespace through the supported GitHub verification flow;
+3. configure the repository's publishing identity/credentials in GitHub Actions or the Central-supported publishing mechanism;
+4. configure artifact signing according to Central's current requirements;
+5. build the canonical standalone renderer before Maven packaging;
+6. run `mvn -f adapters/java-spring/pom.xml verify` and inspect the JAR for both renderer assets;
+7. publish `0.1.0` and verify its POM, sources, Javadocs and runtime assets from Central before announcing it in the main README.
+
+The documentation must say “prepared for Maven Central publication” until the artifact can actually be resolved from Central.
+
+## Python / PyPI
+
+A future Python package should be a framework adapter/static asset package, not a Python rewrite of the renderer. Candidate integrations can include FastAPI, Flask and Django once the adapter API is defined.
+
+Distribution principles:
+
+- publish to PyPI using the ecosystem's Trusted Publishing/OIDC path from GitHub Actions where available;
+- bundle/version the canonical renderer assets and renderer contract in the wheel/sdist;
+- expose a small Python API for obtaining/serving a spec and host page;
+- test the built wheel, not only the source tree;
+- declare renderer-contract compatibility in package metadata/docs;
+- choose the PyPI package name only after checking registry availability.
+
+## Rust / crates.io
+
+A future Rust crate should likewise provide framework/server glue and embedded renderer assets. Good targets can be selected later (for example Axum or Actix Web) without creating a separate rendering implementation.
+
+Before implementation, confirm the current crates.io authentication/publishing mechanism and package-name availability. CI should build the crate/package, verify embedded renderer assets, and test installation from the produced package before release.
+
+## Go modules
+
+Go does not require uploading an artifact to a central package registry. A Go adapter should be a normal Go module and use semantic Git tags; `pkg.go.dev` can index the public module.
+
+If the Go module is kept in a subdirectory of this monorepo, its module path and Git tag must follow Go's submodule tag convention. The renderer JS/CSS can be compiled into the module with `go:embed`, keeping deployments self-contained.
+
+Before the first Go release, choose whether the adapter should remain a monorepo submodule or use a dedicated repository. The decision should optimize import-path stability rather than forcing it to match npm/Maven structure.
+
+## Release compatibility checks
+
+Every adapter release should verify at least:
+
+- renderer contract version expected by the adapter;
+- exact renderer assets are present in the produced package;
+- host HTML loads only local packaged assets by default;
+- no documentation-route secret is serialized to the browser;
+- basic generated page boots with a representative OpenAPI document;
+- package metadata points back to the public FlexDoc source/license;
+- no publishing credential or signing secret exists in the produced package.
+
+## Repository boundary
+
+The core FlexDoc repository is intended to remain public. The renderer, OpenAPI engine, local API-client capabilities, CLI/static distribution and framework adapters benefit from being auditable and self-hostable.
+
+If FlexDoc later adds commercial cloud functionality, account/team sync, hosted secret storage, RBAC/SSO, cloud execution, analytics, monitors and billing can live behind a separate service/repository boundary. Registry publication of the open-source adapters should not depend on that commercial service.

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -21,7 +21,7 @@
   "author": "Vishnu R <vishnurajesh45@gmail.com>",
   "license": "AGPL-3.0-or-later",
   "repository": { "type": "git", "url": "https://github.com/bluejeans117/flexdoc.git", "directory": "packages/backend" },
-  "peerDependencies": { "@nestjs/common": "^10.0.0 || ^11.0.0", "@nestjs/core": "^10.0.0 || ^11.0.0" },
+  "peerDependencies": { "@nestjs/common": "^10.0.0", "@nestjs/core": "^10.0.0" },
   "peerDependenciesMeta": { "@nestjs/common": { "optional": true }, "@nestjs/core": { "optional": true } },
   "dependencies": { "jsonwebtoken": "^9.0.2", "nunjucks": "^3.2.4", "yargs": "^17.7.2" },
   "devDependencies": {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,15 +1,12 @@
 {
   "name": "@bluejeans/flexdoc-backend",
-  "version": "1.0.3",
-  "description": "FlexDoc backend integration for NestJS and other frameworks",
+  "version": "2.0.0",
+  "description": "Thin self-hosted FlexDoc integrations for Express, Fastify, and NestJS",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "bin": {
-    "flexdoc-auth-generator": "dist/scripts/generate-auth.js"
-  },
-  "files": [
-    "dist"
-  ],
+  "bin": { "flexdoc-auth-generator": "dist/scripts/generate-auth.js" },
+  "files": ["dist"],
+  "publishConfig": { "access": "public" },
   "scripts": {
     "build": "tsc && node scripts/copy-renderer.js",
     "dev": "tsc --watch",
@@ -20,54 +17,16 @@
     "generate:basic": "npx ts-node src/scripts/generate-auth.ts basic",
     "generate:bearer": "npx ts-node src/scripts/generate-auth.ts bearer"
   },
-  "keywords": [
-    "openapi-docs",
-    "api-explorer",
-    "swagger-ui",
-    "documentation",
-    "api-docs",
-    "doc-generator",
-    "nestjs",
-    "express",
-    "typescript"
-  ],
+  "keywords": ["openapi", "openapi-docs", "api-explorer", "documentation", "nestjs", "express", "fastify", "typescript"],
   "author": "Vishnu R <vishnurajesh45@gmail.com>",
   "license": "AGPL-3.0-or-later",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/bluejeans117/flexdoc.git",
-    "directory": "packages/backend"
-  },
-  "peerDependencies": {
-    "@nestjs/common": "^10.0.0",
-    "@nestjs/core": "^10.0.0"
-  },
-  "peerDependenciesMeta": {
-    "@nestjs/common": {
-      "optional": true
-    },
-    "@nestjs/core": {
-      "optional": true
-    }
-  },
-  "dependencies": {
-    "jsonwebtoken": "^9.0.2",
-    "nunjucks": "^3.2.4",
-    "yargs": "^17.7.2"
-  },
+  "repository": { "type": "git", "url": "https://github.com/bluejeans117/flexdoc.git", "directory": "packages/backend" },
+  "peerDependencies": { "@nestjs/common": "^10.0.0 || ^11.0.0", "@nestjs/core": "^10.0.0 || ^11.0.0" },
+  "peerDependenciesMeta": { "@nestjs/common": { "optional": true }, "@nestjs/core": { "optional": true } },
+  "dependencies": { "jsonwebtoken": "^9.0.2", "nunjucks": "^3.2.4", "yargs": "^17.7.2" },
   "devDependencies": {
-    "@nestjs/common": "^11.1.3",
-    "@nestjs/core": "^11.1.3",
-    "@nestjs/testing": "^11.1.3",
-    "@types/jest": "^29.5.0",
-    "@types/jsonwebtoken": "^9.0.5",
-    "@types/node": "^20.0.0",
-    "@types/nunjucks": "^3.2.6",
-    "@types/yargs": "^17.0.32",
-    "copyfiles": "^2.4.1",
-    "jest": "^29.5.0",
-    "ts-jest": "^29.1.0",
-    "ts-node": "^10.9.2",
-    "typescript": "^5.0.0"
+    "@nestjs/common": "^11.1.3", "@nestjs/core": "^11.1.3", "@nestjs/testing": "^11.1.3",
+    "@types/jest": "^29.5.0", "@types/jsonwebtoken": "^9.0.5", "@types/node": "^20.0.0", "@types/nunjucks": "^3.2.6", "@types/yargs": "^17.0.32",
+    "copyfiles": "^2.4.1", "jest": "^29.5.0", "ts-jest": "^29.1.0", "ts-node": "^10.9.2", "typescript": "^5.0.0"
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,28 +1,20 @@
 {
   "name": "@bluejeans/flexdoc-client",
-  "version": "1.0.2",
-  "description": "FlexDoc client-side UI components for API documentation",
+  "version": "2.0.0",
+  "description": "FlexDoc's canonical OpenAPI renderer, API explorer, and React components",
   "type": "module",
   "main": "./dist/flexdoc.umd.cjs",
   "module": "./dist/flexdoc.es.js",
   "types": "./dist/index.d.ts",
-  "files": [
-    "dist",
-    "README.md"
-  ],
-  "publishConfig": {
-    "access": "public"
-  },
+  "files": ["dist", "README.md"],
+  "publishConfig": { "access": "public" },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/flexdoc.es.js",
       "require": "./dist/flexdoc.umd.cjs"
     },
-    "./styles.css": {
-      "import": "./dist/assets/index.css",
-      "require": "./dist/assets/index.css"
-    },
+    "./styles.css": { "import": "./dist/assets/index.css", "require": "./dist/assets/index.css" },
     "./standalone.js": "./dist/standalone/flexdoc.standalone.js",
     "./standalone.css": "./dist/standalone/flexdoc.standalone.css"
   },
@@ -35,53 +27,17 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage"
   },
-  "keywords": [
-    "openapi-docs",
-    "api-explorer",
-    "swagger-ui",
-    "documentation",
-    "ui",
-    "react",
-    "typescript"
-  ],
+  "keywords": ["openapi", "openapi-docs", "api-explorer", "api-client", "swagger-ui", "documentation", "react", "typescript"],
   "author": "Vishnu R <vishnurajesh45@gmail.com>",
   "license": "AGPL-3.0-or-later",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/bluejeans117/flexdoc.git",
-    "directory": "packages/client"
-  },
-  "peerDependencies": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
-  },
-  "dependencies": {
-    "js-yaml": "^4.1.0",
-    "lucide-react": "^0.525.0",
-    "prismjs": "^1.29.0"
-  },
+  "repository": { "type": "git", "url": "https://github.com/bluejeans117/flexdoc.git", "directory": "packages/client" },
+  "peerDependencies": { "react": "^19.0.0", "react-dom": "^19.0.0" },
+  "dependencies": { "js-yaml": "^4.1.0", "lucide-react": "^0.525.0", "prismjs": "^1.29.0" },
   "devDependencies": {
-    "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.0",
-    "@testing-library/user-event": "^14.5.0",
-    "@types/jest": "^29.5.0",
-    "@types/node": "^20.0.0",
-    "@types/prismjs": "^1.26.0",
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0",
-    "@typescript-eslint/eslint-plugin": "^7.0.0",
-    "@typescript-eslint/parser": "^7.0.0",
-    "@vitejs/plugin-react": "^4.6.0",
-    "autoprefixer": "^10.4.16",
-    "eslint": "^8.0.0",
-    "eslint-plugin-react-hooks": "^5.0.0",
-    "eslint-plugin-react-refresh": "^0.4.0",
-    "jest": "^29.7.0",
-    "jest-environment-jsdom": "^29.7.0",
-    "postcss": "^8.4.35",
-    "tailwindcss": "^3.4.0",
-    "ts-jest": "^29.1.0",
-    "typescript": "^5.0.0",
-    "vite": "^7.0.0"
+    "@testing-library/jest-dom": "^6.6.3", "@testing-library/react": "^16.0.0", "@testing-library/user-event": "^14.5.0",
+    "@types/jest": "^29.5.0", "@types/node": "^20.0.0", "@types/prismjs": "^1.26.0", "@types/react": "^19.0.0", "@types/react-dom": "^19.0.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.0", "@typescript-eslint/parser": "^7.0.0", "@vitejs/plugin-react": "^4.6.0",
+    "autoprefixer": "^10.4.16", "eslint": "^8.0.0", "eslint-plugin-react-hooks": "^5.0.0", "eslint-plugin-react-refresh": "^0.4.0",
+    "jest": "^29.7.0", "jest-environment-jsdom": "^29.7.0", "postcss": "^8.4.35", "tailwindcss": "^3.4.0", "ts-jest": "^29.1.0", "typescript": "^5.0.0", "vite": "^7.0.0"
   }
 }

--- a/packages/examples/basic-usage/package.json
+++ b/packages/examples/basic-usage/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@bluejeans/flexdoc-client": "^1.0.2",
+    "@bluejeans/flexdoc-client": "^2.0.0",
     "lucide-react": "^0.525.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/packages/examples/interactive-demo/package.json
+++ b/packages/examples/interactive-demo/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@bluejeans/flexdoc-client": "^1.0.2",
+    "@bluejeans/flexdoc-client": "^2.0.0",
     "lucide-react": "^0.525.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/packages/examples/nestjs/package.json
+++ b/packages/examples/nestjs/package.json
@@ -14,7 +14,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
-    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
+    "test:debug": "node --inspect-brk -r tsconfig-paths/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "gen:auth:basic": "npx ts-node ../../backend/src/scripts/generate-auth.ts basic",
     "gen:auth:bearer": "npx ts-node ../../backend/src/scripts/generate-auth.ts bearer"
@@ -27,7 +27,7 @@
     "directory": "packages/examples/nestjs"
   },
   "dependencies": {
-    "@bluejeans/flexdoc-backend": "^1.0.3",
+    "@bluejeans/flexdoc-backend": "^2.0.0",
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",

--- a/packages/examples/nestjs/package.json
+++ b/packages/examples/nestjs/package.json
@@ -14,7 +14,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
-    "test:debug": "node --inspect-brk -r tsconfig-paths/register node_modules/.bin/jest --runInBand",
+    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "gen:auth:basic": "npx ts-node ../../backend/src/scripts/generate-auth.ts basic",
     "gen:auth:bearer": "npx ts-node ../../backend/src/scripts/generate-auth.ts bearer"


### PR DESCRIPTION
## Summary

Prepare the consolidated FlexDoc branch for its first coherent 2.0 release before PR #1 lands on `main`.

### Versions
- version `@bluejeans/flexdoc-client` as `2.0.0`
- version `@bluejeans/flexdoc-backend` as `2.0.0`
- version the new Spring Boot adapter independently as `0.1.0`
- move repository examples to the 2.x workspace packages
- document renderer contract v1 as the cross-ecosystem compatibility boundary

### npm publishing
- move both npm workflows from long-lived `NPM_TOKEN` publishing to npm Trusted Publishing / GitHub OIDC
- scope npm publishing to `js/v<version>` GitHub Releases
- keep dependency installation/building on the project's Node 20 path, then use Node 24 + npm 11 for trusted publishing
- verify release tags match committed package versions
- inspect npm package contents before publication
- include renderer implementation version in the language-neutral renderer bundle manifest
- retain GitHub Release attachment of the renderer bundle

The trusted-publisher relationships for both npm packages have now been configured on npmjs.com against their exact workflow filenames.

### Java / Maven Central
- add Maven Central project/license/developer/SCM metadata
- attach Spring source and Javadoc JARs
- add a `release` Maven profile using `maven-gpg-plugin` for signatures and Sonatype's `central-publishing-maven-plugin` for Central Portal deployment
- configure Central deployment with `autoPublish=true` and `waitUntil=published`
- add `.github/workflows/publish-java.yml`, scoped to `java/v<version>` GitHub Releases
- have CI load the actual Maven release profile with signing skipped so plugin configuration is validated before merge
- keep adapter versions independent while declaring renderer-contract compatibility

The Central namespace, Central user-token secrets, public signing key, private signing-key secret, and signing passphrase have been configured outside the repository. No publishing credentials are committed.

### Documentation and public-repo hygiene
- rewrite the stale root README around the actual unified renderer / API explorer architecture
- correct the license from stale MIT wording to the repository's AGPL-3.0-or-later license
- remove old package names and unsupported/overstated feature claims
- document current React, Node and Spring surfaces and explicit Maven publication status
- document ecosystem-scoped release tags and the automated npm/Maven release paths
- add `.env.*` ignore coverage while preserving example env files
- update deprecated GitHub Actions major versions used by CI

## Release model

The existing JavaScript packages move together to `2.0.0` because the backend packages the canonical renderer and both already have 1.x history. New ecosystem adapters start with their own semver (`0.1.0` for Spring) and advertise compatibility through renderer contract v1 rather than forcing npm/Maven/PyPI/crates/Go versions to match.

Release tags are ecosystem-scoped:
- `js/v2.0.0` publishes both npm packages
- `java/v0.1.0` publishes the Spring Boot starter

## Validation

CI validates:
- clean npm install from the checked-in lock
- client tests and standalone build
- renderer contract validation
- backend tests/build and packaged renderer checks
- Maven release-profile resolution with GPG signing skipped
- release Java JAR plus source/Javadoc JAR checks
- embedded Java renderer JS/CSS checks

Actual registry publication is intentionally not exercised from PR CI. It occurs only from the corresponding published GitHub Release after this code reaches the default branch.

This PR targets PR #1's branch intentionally; PR #1 should absorb this release preparation before being merged to `main`.