### PR TITLE
Fix client package type exports for 2.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Build client and standalone renderer
         run: npm run build:client
 
+      - name: Verify packed client package from a clean consumer
+        run: node scripts/verify-client-package.mjs
+
       - name: Verify standalone renderer artifacts
         run: |
           test -s packages/client/dist/standalone/flexdoc.standalone.js

--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Build client package
         run: npm run build -w packages/client
 
+      - name: Verify packed client package from a clean consumer
+        run: node scripts/verify-client-package.mjs
+
       - name: Verify JavaScript release tag matches package version
         run: |
           VERSION=$(node -p "require('./packages/client/package.json').version")

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Browser-side loading of cross-origin external OpenAPI references is subject to t
 
 | Package | Version | Purpose |
 | --- | --- | --- |
-| `@bluejeans/flexdoc-client` | `2.0.0` | React components plus the canonical standalone renderer |
-| `@bluejeans/flexdoc-backend` | `2.0.0` | Thin Express, Fastify and NestJS integrations |
-| `io.github.bluejeans117.flexdoc:flexdoc-spring-boot-starter` | `0.1.0` | Spring Boot adapter; Maven Central publication is prepared separately |
+| `@bluejeans/flexdoc-client` | `2.0.1` | React components plus the canonical standalone renderer |
+| `@bluejeans/flexdoc-backend` | `2.0.1` | Thin Express, Fastify and NestJS integrations |
+| `io.github.bluejeans117.flexdoc:flexdoc-spring-boot-starter` | `0.1.0` | Spring Boot adapter published on Maven Central |
 
 Language adapters have independent ecosystem versions. Compatibility is governed by the renderer contract rather than forcing npm, Maven, PyPI, crates.io and Go modules to share one version number. See [Distribution and versioning](./docs/distribution.md).
 
@@ -89,7 +89,15 @@ await setupNestFlexDoc(app, {
 
 ## Spring Boot
 
-The Java adapter is currently built from this repository and is prepared for Maven Central publication. Once published, applications using springdoc can use `/v3/api-docs` without custom spec plumbing:
+The Java adapter is published on Maven Central as `io.github.bluejeans117.flexdoc:flexdoc-spring-boot-starter:0.1.0`. Applications using springdoc can use `/v3/api-docs` without custom spec plumbing:
+
+```xml
+<dependency>
+  <groupId>io.github.bluejeans117.flexdoc</groupId>
+  <artifactId>flexdoc-spring-boot-starter</artifactId>
+  <version>0.1.0</version>
+</dependency>
+```
 
 ```yaml
 flexdoc:
@@ -99,7 +107,7 @@ flexdoc:
   theme: dark
 ```
 
-See [`adapters/java-spring`](./adapters/java-spring/README.md) for the complete integration and current publication status.
+See [`adapters/java-spring`](./adapters/java-spring/README.md) for the complete integration.
 
 ## Architecture
 
@@ -136,7 +144,7 @@ npm run build --workspace=@bluejeans/flexdoc-backend
 mvn -f adapters/java-spring/pom.xml verify
 ```
 
-CI additionally verifies that backend and Java artifacts contain the canonical standalone renderer assets.
+CI additionally verifies the packed npm client from a clean TypeScript consumer and checks that backend and Java artifacts contain the canonical standalone renderer assets.
 
 ## Release and distribution
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bluejeans/flexdoc-backend",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Thin self-hosted FlexDoc integrations for Express, Fastify, and NestJS",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -21,7 +21,7 @@
   "style": "./dist/assets/index.css",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build && vite build --config vite.standalone.config.ts",
+    "build": "vite build && vite build --config vite.standalone.config.ts && tsc --emitDeclarationOnly",
     "preview": "vite preview",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@bluejeans/flexdoc-client",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "FlexDoc's canonical OpenAPI renderer, API explorer, and React components",
   "type": "module",
   "main": "./dist/flexdoc.umd.cjs",
   "module": "./dist/flexdoc.es.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "files": ["dist", "README.md"],
   "publishConfig": { "access": "public" },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/flexdoc.es.js",
       "require": "./dist/flexdoc.umd.cjs"
     },
@@ -21,7 +21,7 @@
   "style": "./dist/assets/index.css",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build && vite build --config vite.standalone.config.ts && tsc --emitDeclarationOnly --outDir dist",
+    "build": "tsc && vite build && vite build --config vite.standalone.config.ts",
     "preview": "vite preview",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -21,6 +21,10 @@
     "emitDeclarationOnly": true
   },
   "include": ["src"],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/setupTests.ts"
+  ],
   "references": [{ "path": "./tsconfig.node.json" }]
 }
-

--- a/scripts/verify-client-package.mjs
+++ b/scripts/verify-client-package.mjs
@@ -1,0 +1,135 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const repoRoot = process.cwd();
+const packageDir = resolve(repoRoot, 'packages/client');
+const manifest = JSON.parse(readFileSync(join(packageDir, 'package.json'), 'utf8'));
+const tempRoot = mkdtempSync(join(tmpdir(), 'flexdoc-client-package-'));
+const packDir = join(tempRoot, 'pack');
+const consumerDir = join(tempRoot, 'consumer');
+mkdirSync(packDir);
+mkdirSync(consumerDir);
+
+function run(command, args, options = {}) {
+  return execFileSync(command, args, {
+    cwd: options.cwd ?? repoRoot,
+    encoding: 'utf8',
+    stdio: options.capture ? ['ignore', 'pipe', 'inherit'] : 'inherit',
+    ...options,
+  });
+}
+
+function collectExportPaths(value, paths = []) {
+  if (typeof value === 'string') {
+    if (value.startsWith('./')) paths.push(value);
+    return paths;
+  }
+  if (value && typeof value === 'object') {
+    for (const child of Object.values(value)) collectExportPaths(child, paths);
+  }
+  return paths;
+}
+
+try {
+  const packOutput = run(
+    'npm',
+    ['pack', '-w', 'packages/client', '--pack-destination', packDir, '--json'],
+    { capture: true },
+  );
+  const [packed] = JSON.parse(packOutput);
+  if (!packed?.filename) throw new Error('npm pack did not report a tarball filename');
+
+  const tarball = join(packDir, packed.filename);
+  const entries = new Set(
+    run('tar', ['-tzf', tarball], { capture: true })
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map((entry) => entry.replace(/^package\//, '').replace(/\/$/, '')),
+  );
+
+  const declaredPaths = [manifest.main, manifest.module, manifest.types, manifest.style]
+    .filter(Boolean)
+    .concat(collectExportPaths(manifest.exports));
+
+  const missing = [...new Set(declaredPaths)]
+    .map((entry) => entry.replace(/^\.\//, ''))
+    .filter((entry) => !entries.has(entry));
+
+  if (missing.length) {
+    throw new Error(`Published package metadata points to missing files:\n${missing.join('\n')}`);
+  }
+
+  const declarationEntry = String(manifest.types ?? '').replace(/^\.\//, '');
+  if (!declarationEntry || !entries.has(declarationEntry)) {
+    throw new Error(`Type declaration entry is missing from tarball: ${manifest.types}`);
+  }
+
+  const unwantedDeclarations = [...entries].filter(
+    (entry) =>
+      entry.startsWith('dist/types/') &&
+      (entry.endsWith('.test.d.ts') || entry.endsWith('/setupTests.d.ts') || entry === 'dist/types/setupTests.d.ts'),
+  );
+  if (unwantedDeclarations.length) {
+    throw new Error(`Test declarations leaked into package:\n${unwantedDeclarations.join('\n')}`);
+  }
+
+  writeFileSync(
+    join(consumerDir, 'package.json'),
+    JSON.stringify({ name: 'flexdoc-package-smoke-test', private: true, type: 'module' }, null, 2),
+  );
+
+  run(
+    'npm',
+    [
+      'install',
+      '--ignore-scripts',
+      '--no-audit',
+      '--no-fund',
+      '--package-lock=false',
+      tarball,
+      'react@19',
+      'react-dom@19',
+      'typescript@5',
+    ],
+    { cwd: consumerDir },
+  );
+
+  writeFileSync(
+    join(consumerDir, 'consumer.ts'),
+    `import { FlexDoc, sampleSpec, OpenAPIParser, buildRequest } from '@bluejeans/flexdoc-client';\n` +
+      `import type { FlexDocProps, OpenAPISpec } from '@bluejeans/flexdoc-client';\n\n` +
+      `const component: typeof FlexDoc = FlexDoc;\n` +
+      `const spec: OpenAPISpec = sampleSpec;\n` +
+      `const parser = OpenAPIParser;\n` +
+      `const requestBuilder = buildRequest;\n` +
+      `const props: FlexDocProps = { spec };\n` +
+      `void [component, parser, requestBuilder, props];\n`,
+  );
+
+  writeFileSync(
+    join(consumerDir, 'tsconfig.json'),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          target: 'ES2020',
+          module: 'ESNext',
+          moduleResolution: 'Bundler',
+          jsx: 'react-jsx',
+          strict: true,
+          skipLibCheck: true,
+          noEmit: true,
+        },
+        include: ['consumer.ts'],
+      },
+      null,
+      2,
+    ),
+  );
+
+  run('npm', ['exec', '--', 'tsc', '-p', 'tsconfig.json'], { cwd: consumerDir });
+  console.log(`Verified packed ${manifest.name}@${manifest.version} from a clean TypeScript consumer.`);
+} finally {
+  rmSync(tempRoot, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

Fix the npm packaging defect in `@bluejeans/flexdoc-client@2.0.0` where `package.json` points TypeScript consumers at `dist/index.d.ts`, while the actual declaration entry is emitted as `dist/types/index.d.ts`.

## Changes

- bump `@bluejeans/flexdoc-client` to `2.0.1`
- bump `@bluejeans/flexdoc-backend` to `2.0.1` to keep the coordinated JavaScript release line aligned
- point both `types` and `exports["."].types` at `./dist/types/index.d.ts`
- emit declarations after the Vite builds so Vite's output-directory cleanup cannot delete them
- exclude test/setup declarations from the published client declaration tree
- add `scripts/verify-client-package.mjs`, which:
  - builds an actual npm tarball
  - verifies every declared package entry/export path exists in the tarball
  - rejects leaked test declarations
  - installs the tarball into a fresh temporary consumer
  - compiles imports of `FlexDoc`, `sampleSpec`, `OpenAPIParser`, `buildRequest`, `FlexDocProps`, and `OpenAPISpec`
- run that packed-consumer check in normal CI and again before client publication
- update README package versions and Maven Central status

## Why

The 2.0.0 publish itself was built from the correct FlexDoc 2.0 source and contains the current runtime/declarations, but the package metadata references a declaration path that is not present in the tarball. That can cause TypeScript consumers to fail declaration resolution or surface stale/fallback type information.

The new regression test also caught an ordering issue during this PR: declaration output produced before Vite was erased when Vite cleaned `dist`. The build now emits declarations last, and CI validates the final packed artifact rather than the source tree.

## Release

After merge, publish GitHub Release/tag:

`js/v2.0.1`

No Java patch release is required because the defect is specific to the npm React/TypeScript package metadata, not the standalone renderer embedded in the Spring artifact.