### PR TITLE
Fix dual ESM/CommonJS type resolution for 2.0.2

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bluejeans/flexdoc-backend",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Thin self-hosted FlexDoc integrations for Express, Fastify, and NestJS",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,18 +1,23 @@
 {
   "name": "@bluejeans/flexdoc-client",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "FlexDoc's canonical OpenAPI renderer, API explorer, and React components",
   "type": "module",
   "main": "./dist/flexdoc.umd.cjs",
   "module": "./dist/flexdoc.es.js",
-  "types": "./dist/types/index.d.ts",
+  "types": "./dist/types/esm/index.d.ts",
   "files": ["dist", "README.md"],
   "publishConfig": { "access": "public" },
   "exports": {
     ".": {
-      "types": "./dist/types/index.d.ts",
-      "import": "./dist/flexdoc.es.js",
-      "require": "./dist/flexdoc.umd.cjs"
+      "import": {
+        "types": "./dist/types/esm/index.d.ts",
+        "default": "./dist/flexdoc.es.js"
+      },
+      "require": {
+        "types": "./dist/types/cjs/index.d.cts",
+        "default": "./dist/flexdoc.umd.cjs"
+      }
     },
     "./styles.css": { "import": "./dist/assets/index.css", "require": "./dist/assets/index.css" },
     "./standalone.js": "./dist/standalone/flexdoc.standalone.js",
@@ -21,7 +26,7 @@
   "style": "./dist/assets/index.css",
   "scripts": {
     "dev": "vite",
-    "build": "vite build && vite build --config vite.standalone.config.ts && tsc --emitDeclarationOnly",
+    "build": "vite build && vite build --config vite.standalone.config.ts && tsc --emitDeclarationOnly && node ../../scripts/prepare-client-types.mjs",
     "preview": "vite preview",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/scripts/prepare-client-types.mjs
+++ b/scripts/prepare-client-types.mjs
@@ -1,5 +1,5 @@
 import { cpSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs';
-import { dirname, join, relative, resolve } from 'node:path';
+import { join, relative, resolve } from 'node:path';
 
 const packageDir = resolve(process.cwd());
 const rawDir = join(packageDir, 'dist/types');
@@ -24,21 +24,23 @@ function walk(dir, visit) {
   }
 }
 
-function addJsExtensions(source) {
+function addExtension(source, extension) {
   return source.replace(/(from\s+['"]|export\s+\*\s+from\s+['"]|import\s*\(\s*['"])(\.{1,2}\/[^'"]+)(['"])/g, (match, prefix, specifier, suffix) => {
     if (/\.(?:js|mjs|cjs|json)$/.test(specifier)) return match;
-    return `${prefix}${specifier}.js${suffix}`;
+    return `${prefix}${specifier}${extension}${suffix}`;
   });
 }
 
 walk(esmDir, (path) => {
   if (!path.endsWith('.d.ts')) return;
-  writeFileSync(path, addJsExtensions(readFileSync(path, 'utf8')));
+  writeFileSync(path, addExtension(readFileSync(path, 'utf8'), '.js'));
 });
 
 const cjsFiles = [];
 walk(cjsDir, (path) => {
-  if (path.endsWith('.d.ts')) cjsFiles.push(path);
+  if (!path.endsWith('.d.ts')) return;
+  writeFileSync(path, addExtension(readFileSync(path, 'utf8'), '.cjs'));
+  cjsFiles.push(path);
 });
 for (const path of cjsFiles.sort((a, b) => b.length - a.length)) {
   renameSync(path, path.replace(/\.d\.ts$/, '.d.cts'));

--- a/scripts/prepare-client-types.mjs
+++ b/scripts/prepare-client-types.mjs
@@ -1,0 +1,53 @@
+import { cpSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+
+const packageDir = resolve(process.cwd());
+const rawDir = join(packageDir, 'dist/types');
+const tempDir = join(packageDir, 'dist/.types-raw');
+const esmDir = join(packageDir, 'dist/types/esm');
+const cjsDir = join(packageDir, 'dist/types/cjs');
+
+rmSync(tempDir, { recursive: true, force: true });
+cpSync(rawDir, tempDir, { recursive: true });
+rmSync(rawDir, { recursive: true, force: true });
+mkdirSync(esmDir, { recursive: true });
+mkdirSync(cjsDir, { recursive: true });
+cpSync(tempDir, esmDir, { recursive: true });
+cpSync(tempDir, cjsDir, { recursive: true });
+rmSync(tempDir, { recursive: true, force: true });
+
+function walk(dir, visit) {
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name);
+    if (statSync(path).isDirectory()) walk(path, visit);
+    else visit(path);
+  }
+}
+
+function addJsExtensions(source) {
+  return source.replace(/(from\s+['"]|export\s+\*\s+from\s+['"]|import\s*\(\s*['"])(\.{1,2}\/[^'"]+)(['"])/g, (match, prefix, specifier, suffix) => {
+    if (/\.(?:js|mjs|cjs|json)$/.test(specifier)) return match;
+    return `${prefix}${specifier}.js${suffix}`;
+  });
+}
+
+walk(esmDir, (path) => {
+  if (!path.endsWith('.d.ts')) return;
+  writeFileSync(path, addJsExtensions(readFileSync(path, 'utf8')));
+});
+
+const cjsFiles = [];
+walk(cjsDir, (path) => {
+  if (path.endsWith('.d.ts')) cjsFiles.push(path);
+});
+for (const path of cjsFiles.sort((a, b) => b.length - a.length)) {
+  renameSync(path, path.replace(/\.d\.ts$/, '.d.cts'));
+}
+
+const esmIndex = join(esmDir, 'index.d.ts');
+const cjsIndex = join(cjsDir, 'index.d.cts');
+if (!statSync(esmIndex).isFile() || !statSync(cjsIndex).isFile()) {
+  throw new Error('Failed to prepare dual declaration entrypoints');
+}
+
+console.log(`Prepared client declarations: ${relative(packageDir, esmIndex)} and ${relative(packageDir, cjsIndex)}`);

--- a/scripts/verify-client-package.mjs
+++ b/scripts/verify-client-package.mjs
@@ -8,128 +8,39 @@ const packageDir = resolve(repoRoot, 'packages/client');
 const manifest = JSON.parse(readFileSync(join(packageDir, 'package.json'), 'utf8'));
 const tempRoot = mkdtempSync(join(tmpdir(), 'flexdoc-client-package-'));
 const packDir = join(tempRoot, 'pack');
-const consumerDir = join(tempRoot, 'consumer');
 mkdirSync(packDir);
-mkdirSync(consumerDir);
 
 function run(command, args, options = {}) {
-  return execFileSync(command, args, {
-    cwd: options.cwd ?? repoRoot,
-    encoding: 'utf8',
-    stdio: options.capture ? ['ignore', 'pipe', 'inherit'] : 'inherit',
-    ...options,
-  });
+  return execFileSync(command, args, { cwd: options.cwd ?? repoRoot, encoding: 'utf8', stdio: options.capture ? ['ignore', 'pipe', 'inherit'] : 'inherit', ...options });
 }
-
 function collectExportPaths(value, paths = []) {
-  if (typeof value === 'string') {
-    if (value.startsWith('./')) paths.push(value);
-    return paths;
-  }
-  if (value && typeof value === 'object') {
-    for (const child of Object.values(value)) collectExportPaths(child, paths);
-  }
+  if (typeof value === 'string') { if (value.startsWith('./')) paths.push(value); return paths; }
+  if (value && typeof value === 'object') for (const child of Object.values(value)) collectExportPaths(child, paths);
   return paths;
+}
+function smoke(name, type, sourceName, compilerOptions, tarball) {
+  const dir = join(tempRoot, name); mkdirSync(dir);
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: `flexdoc-${name}`, private: true, type }, null, 2));
+  run('npm', ['install','--ignore-scripts','--no-audit','--no-fund','--package-lock=false',tarball,'react@19','react-dom@19','typescript@5'], { cwd: dir });
+  writeFileSync(join(dir, sourceName), `import { FlexDoc, sampleSpec, OpenAPIParser, buildRequest } from '@bluejeans/flexdoc-client';\nimport type { FlexDocProps, OpenAPISpec } from '@bluejeans/flexdoc-client';\nconst component: typeof FlexDoc = FlexDoc;\nconst spec: OpenAPISpec = sampleSpec;\nconst parser = OpenAPIParser;\nconst requestBuilder = buildRequest;\nconst props: FlexDocProps = { spec };\nvoid [component, parser, requestBuilder, props];\n`);
+  writeFileSync(join(dir, 'tsconfig.json'), JSON.stringify({ compilerOptions: { target:'ES2020', jsx:'react-jsx', strict:true, skipLibCheck:false, noEmit:true, ...compilerOptions }, include:[sourceName] }, null, 2));
+  run('npm', ['exec','--','tsc','-p','tsconfig.json'], { cwd: dir });
 }
 
 try {
-  const packOutput = run(
-    'npm',
-    ['pack', '-w', 'packages/client', '--pack-destination', packDir, '--json'],
-    { capture: true },
-  );
-  const [packed] = JSON.parse(packOutput);
+  const [packed] = JSON.parse(run('npm', ['pack','-w','packages/client','--pack-destination',packDir,'--json'], { capture:true }));
   if (!packed?.filename) throw new Error('npm pack did not report a tarball filename');
-
   const tarball = join(packDir, packed.filename);
-  const entries = new Set(
-    run('tar', ['-tzf', tarball], { capture: true })
-      .split(/\r?\n/)
-      .filter(Boolean)
-      .map((entry) => entry.replace(/^package\//, '').replace(/\/$/, '')),
-  );
+  const entries = new Set(run('tar', ['-tzf',tarball], { capture:true }).split(/\r?\n/).filter(Boolean).map(e => e.replace(/^package\//,'').replace(/\/$/,'')));
+  const declared = [manifest.main,manifest.module,manifest.types,manifest.style].filter(Boolean).concat(collectExportPaths(manifest.exports));
+  const missing = [...new Set(declared)].map(e => e.replace(/^\.\//,'')).filter(e => !entries.has(e));
+  if (missing.length) throw new Error(`Published package metadata points to missing files:\n${missing.join('\n')}`);
+  for (const required of ['dist/types/esm/index.d.ts','dist/types/cjs/index.d.cts']) if (!entries.has(required)) throw new Error(`Missing declaration entry: ${required}`);
+  const unwanted = [...entries].filter(e => e.startsWith('dist/types/') && (e.includes('.test.d.') || e.includes('/setupTests.d.')));
+  if (unwanted.length) throw new Error(`Test declarations leaked into package:\n${unwanted.join('\n')}`);
 
-  const declaredPaths = [manifest.main, manifest.module, manifest.types, manifest.style]
-    .filter(Boolean)
-    .concat(collectExportPaths(manifest.exports));
-
-  const missing = [...new Set(declaredPaths)]
-    .map((entry) => entry.replace(/^\.\//, ''))
-    .filter((entry) => !entries.has(entry));
-
-  if (missing.length) {
-    throw new Error(`Published package metadata points to missing files:\n${missing.join('\n')}`);
-  }
-
-  const declarationEntry = String(manifest.types ?? '').replace(/^\.\//, '');
-  if (!declarationEntry || !entries.has(declarationEntry)) {
-    throw new Error(`Type declaration entry is missing from tarball: ${manifest.types}`);
-  }
-
-  const unwantedDeclarations = [...entries].filter(
-    (entry) =>
-      entry.startsWith('dist/types/') &&
-      (entry.endsWith('.test.d.ts') || entry.endsWith('/setupTests.d.ts') || entry === 'dist/types/setupTests.d.ts'),
-  );
-  if (unwantedDeclarations.length) {
-    throw new Error(`Test declarations leaked into package:\n${unwantedDeclarations.join('\n')}`);
-  }
-
-  writeFileSync(
-    join(consumerDir, 'package.json'),
-    JSON.stringify({ name: 'flexdoc-package-smoke-test', private: true, type: 'module' }, null, 2),
-  );
-
-  run(
-    'npm',
-    [
-      'install',
-      '--ignore-scripts',
-      '--no-audit',
-      '--no-fund',
-      '--package-lock=false',
-      tarball,
-      'react@19',
-      'react-dom@19',
-      'typescript@5',
-    ],
-    { cwd: consumerDir },
-  );
-
-  writeFileSync(
-    join(consumerDir, 'consumer.ts'),
-    `import { FlexDoc, sampleSpec, OpenAPIParser, buildRequest } from '@bluejeans/flexdoc-client';\n` +
-      `import type { FlexDocProps, OpenAPISpec } from '@bluejeans/flexdoc-client';\n\n` +
-      `const component: typeof FlexDoc = FlexDoc;\n` +
-      `const spec: OpenAPISpec = sampleSpec;\n` +
-      `const parser = OpenAPIParser;\n` +
-      `const requestBuilder = buildRequest;\n` +
-      `const props: FlexDocProps = { spec };\n` +
-      `void [component, parser, requestBuilder, props];\n`,
-  );
-
-  writeFileSync(
-    join(consumerDir, 'tsconfig.json'),
-    JSON.stringify(
-      {
-        compilerOptions: {
-          target: 'ES2020',
-          module: 'ESNext',
-          moduleResolution: 'Bundler',
-          jsx: 'react-jsx',
-          strict: true,
-          skipLibCheck: true,
-          noEmit: true,
-        },
-        include: ['consumer.ts'],
-      },
-      null,
-      2,
-    ),
-  );
-
-  run('npm', ['exec', '--', 'tsc', '-p', 'tsconfig.json'], { cwd: consumerDir });
-  console.log(`Verified packed ${manifest.name}@${manifest.version} from a clean TypeScript consumer.`);
-} finally {
-  rmSync(tempRoot, { recursive: true, force: true });
-}
+  smoke('bundler-esm','module','consumer.ts',{ module:'ESNext', moduleResolution:'Bundler' },tarball);
+  smoke('nodenext-esm','module','consumer.mts',{ module:'NodeNext', moduleResolution:'NodeNext' },tarball);
+  smoke('nodenext-cjs','commonjs','consumer.cts',{ module:'NodeNext', moduleResolution:'NodeNext' },tarball);
+  console.log(`Verified packed ${manifest.name}@${manifest.version} in Bundler ESM, NodeNext ESM, and NodeNext CommonJS consumers.`);
+} finally { rmSync(tempRoot, { recursive:true, force:true }); }

--- a/scripts/verify-client-package.mjs
+++ b/scripts/verify-client-package.mjs
@@ -21,7 +21,7 @@ function collectExportPaths(value, paths = []) {
 function smoke(name, type, sourceName, compilerOptions, tarball) {
   const dir = join(tempRoot, name); mkdirSync(dir);
   writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: `flexdoc-${name}`, private: true, type }, null, 2));
-  run('npm', ['install','--ignore-scripts','--no-audit','--no-fund','--package-lock=false',tarball,'react@19','react-dom@19','typescript@5'], { cwd: dir });
+  run('npm', ['install','--ignore-scripts','--no-audit','--no-fund','--package-lock=false',tarball,'react@19','react-dom@19','@types/react@19','@types/react-dom@19','typescript@5'], { cwd: dir });
   writeFileSync(join(dir, sourceName), `import { FlexDoc, sampleSpec, OpenAPIParser, buildRequest } from '@bluejeans/flexdoc-client';\nimport type { FlexDocProps, OpenAPISpec } from '@bluejeans/flexdoc-client';\nconst component: typeof FlexDoc = FlexDoc;\nconst spec: OpenAPISpec = sampleSpec;\nconst parser = OpenAPIParser;\nconst requestBuilder = buildRequest;\nconst props: FlexDocProps = { spec };\nvoid [component, parser, requestBuilder, props];\n`);
   writeFileSync(join(dir, 'tsconfig.json'), JSON.stringify({ compilerOptions: { target:'ES2020', jsx:'react-jsx', strict:true, skipLibCheck:false, noEmit:true, ...compilerOptions }, include:[sourceName] }, null, 2));
   run('npm', ['exec','--','tsc','-p','tsconfig.json'], { cwd: dir });


### PR DESCRIPTION
## Summary

Fix the remaining JavaScript package typing issue in `@bluejeans/flexdoc-client` for consumers using NodeNext/CommonJS resolution.

## Changes

- bump `@bluejeans/flexdoc-client` to `2.0.2`
- bump `@bluejeans/flexdoc-backend` to `2.0.2` to keep the coordinated JavaScript release line aligned
- publish separate declaration entrypoints for ESM and CommonJS:
  - `dist/types/esm/index.d.ts`
  - `dist/types/cjs/index.d.cts`
- use conditional `types` entries under the package `exports` map so `import` and `require` consumers resolve the matching declaration mode
- post-process ESM declaration imports with explicit `.js` specifiers for NodeNext compatibility
- generate a parallel CommonJS `.d.cts` declaration tree
- strengthen the packed-package smoke test to install the real tarball and compile three consumers with `skipLibCheck: false`:
  - ESM + `moduleResolution: Bundler`
  - ESM + `module/moduleResolution: NodeNext`
  - CommonJS + `module/moduleResolution: NodeNext`

## Why

`2.0.1` correctly ships the runtime and the current declaration symbols, but it exposes one `.d.ts` entry for both ESM and CommonJS runtime entrypoints. Under NodeNext/CommonJS resolution, TypeScript can therefore resolve `flexdoc.umd.cjs` without a matching CommonJS declaration and treat the package as untyped.

This PR makes the declaration format mirror the dual runtime package and expands CI to cover the consumer mode that surfaced the issue.

## Release

After merge, publish GitHub Release/tag:

`js/v2.0.2`

No Java patch release is required.