### PR TITLE
Add Playwright browser E2E and visual regression coverage

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,50 @@
+name: Browser E2E
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  playwright:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install repository dependencies
+        run: npm ci
+
+      - name: Install pinned Playwright test runner
+        run: npm install --no-save --package-lock=false @playwright/test@1.62.1
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run browser E2E and generate initial visual baselines
+        run: npx playwright test --update-snapshots
+
+      - name: Upload visual baselines
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-visual-baselines
+          path: e2e/**/*-snapshots/*.png
+          if-no-files-found: error
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          if-no-files-found: ignore

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,15 +31,16 @@ jobs:
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
 
-      - name: Run browser E2E and generate initial visual baselines
-        run: npx playwright test --update-snapshots
+      - name: Run browser E2E and visual regression checks
+        run: npx playwright test
 
-      - name: Upload visual baselines
+      - name: Upload Playwright test output
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-visual-baselines
-          path: e2e/**/*-snapshots/*.png
-          if-no-files-found: error
+          name: playwright-test-results
+          path: test-results/
+          if-no-files-found: ignore
 
       - name: Upload Playwright report
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ dist-ssr
 
 # Coverage directories
 coverage
+
+# Playwright local output (visual baselines under e2e/**/*-snapshots stay tracked)
+playwright-report/
+test-results/

--- a/e2e/flexdoc.spec.cjs
+++ b/e2e/flexdoc.spec.cjs
@@ -1,0 +1,80 @@
+const { test, expect } = require('@playwright/test');
+
+test('deep links directly to an operation', async ({ page }) => {
+  await page.goto('/e2e/index.html#get-pets-id');
+  await expect(page.getByRole('heading', { name: 'Get a pet' })).toBeVisible();
+  await expect(page.getByText('/pets/{id}', { exact: true }).last()).toBeVisible();
+  await expect(page).toHaveURL(/#get-pets-id$/);
+});
+
+test('desktop search, Try It, response viewer, and code samples work together', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'chromium-desktop', 'desktop navigation coverage');
+
+  const requests = [];
+  await page.route('https://api.example.test/**', async (route) => {
+    requests.push({ url: route.request().url(), headers: route.request().headers() });
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: '42', name: 'Milo' }),
+      headers: { 'x-flexdoc-test': 'browser-e2e' },
+    });
+  });
+
+  await page.goto('/e2e/index.html');
+  const search = page.getByPlaceholder('Search endpoints...');
+  await search.fill('payload');
+  await expect(page.getByText('/payload', { exact: true })).toBeVisible();
+  await expect(page.getByText('/pets/{id}', { exact: true })).toHaveCount(0);
+  await search.clear();
+
+  await page.locator('button').filter({ hasText: '/pets/{id}' }).click();
+  await expect(page).toHaveURL(/#get-pets-id$/);
+  await expect(page.getByRole('heading', { name: 'Get a pet' })).toBeVisible();
+
+  await page.getByLabel('path id').fill('42');
+  await page.getByLabel('query locale').fill('de');
+  await page.getByLabel('query tags').fill('["one","two"]');
+  await page.getByLabel('query filter').fill('{"role":"admin"}');
+  await page.getByLabel('header X-Trace').fill('trace-42');
+  await page.getByLabel('cookie session').fill('session-42');
+  await page.getByLabel('bearer credential').fill('token-42');
+
+  await page.getByRole('button', { name: 'Send request' }).click();
+  await expect(page.getByText(/Response\s+200\s+OK/)).toBeVisible();
+  await expect(page.locator('pre').filter({ hasText: 'Milo' })).toBeVisible();
+
+  expect(requests).toHaveLength(1);
+  expect(requests[0].url).toBe('https://api.example.test/pets/42?locale=de&tags=one&tags=two&filter%5Brole%5D=admin');
+  expect(requests[0].headers.authorization).toBe('Bearer token-42');
+  expect(requests[0].headers['x-trace']).toBe('trace-42');
+  expect(requests[0].headers.cookie).toContain('session=session-42');
+
+  await page.getByRole('tab', { name: 'JavaScript' }).click();
+  await expect(page.locator('pre').filter({ hasText: 'fetch(' })).toBeVisible();
+  await expect(page.locator('pre').filter({ hasText: 'Bearer token-42' })).toBeVisible();
+});
+
+test('mobile navigation is accessible and closes after endpoint selection', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'chromium-mobile', 'mobile navigation coverage');
+
+  await page.goto('/e2e/index.html');
+  await page.getByRole('button', { name: 'Open API navigation' }).click();
+  const dialog = page.getByRole('dialog', { name: 'API navigation' });
+  await expect(dialog).toBeVisible();
+  await dialog.getByPlaceholder('Search endpoints...').fill('pet');
+  await dialog.locator('button').filter({ hasText: '/pets/{id}' }).click();
+  await expect(dialog).toBeHidden();
+  await expect(page.getByRole('heading', { name: 'Get a pet' })).toBeVisible();
+  await expect(page).toHaveURL(/#get-pets-id$/);
+});
+
+test('canonical overview visual remains stable', async ({ page }) => {
+  await page.goto('/e2e/index.html');
+  await expect(page.getByText('FlexDoc Browser Fixture', { exact: true }).first()).toBeVisible();
+  await expect(page).toHaveScreenshot('overview.png', {
+    fullPage: true,
+    animations: 'disabled',
+    caret: 'hide',
+  });
+});

--- a/e2e/flexdoc.spec.cjs
+++ b/e2e/flexdoc.spec.cjs
@@ -49,7 +49,10 @@ test('desktop search, Try It, response viewer, and code samples work together', 
   expect(requests[0].url).toBe('https://api.example.test/pets/42?locale=de&tags=one&tags=two&filter%5Brole%5D=admin');
   expect(requests[0].headers.authorization).toBe('Bearer token-42');
   expect(requests[0].headers['x-trace']).toBe('trace-42');
-  expect(requests[0].headers.cookie).toContain('session=session-42');
+  // The canonical request model serializes OpenAPI cookie parameters, but browser fetch
+  // forbids application code from setting the Cookie header. Browser execution therefore
+  // relies on the cookie jar/credentials policy rather than a synthetic Cookie header.
+  expect(requests[0].headers.cookie).toBeUndefined();
 
   await page.getByRole('tab', { name: 'JavaScript' }).click();
   await expect(page.locator('pre').filter({ hasText: 'fetch(' })).toBeVisible();

--- a/e2e/flexdoc.spec.cjs
+++ b/e2e/flexdoc.spec.cjs
@@ -1,4 +1,10 @@
+const { createHash } = require('node:crypto');
 const { test, expect } = require('@playwright/test');
+
+const overviewDigests = {
+  'chromium-desktop': '3b1db4cc58e169c89cf179a05d0412af49556c7c42554d571a4c917c275eca7c',
+  'chromium-mobile': '244c39f50f4ab2f44a664bf4b2637dfc596d239e62b9f005cc9802521e3af750',
+};
 
 test('deep links directly to an operation', async ({ page }) => {
   await page.goto('/e2e/index.html#get-pets-id');
@@ -73,12 +79,11 @@ test('mobile navigation is accessible and closes after endpoint selection', asyn
   await expect(page).toHaveURL(/#get-pets-id$/);
 });
 
-test('canonical overview visual remains stable', async ({ page }) => {
+test('canonical overview visual remains stable', async ({ page }, testInfo) => {
   await page.goto('/e2e/index.html');
   await expect(page.getByText('FlexDoc Browser Fixture', { exact: true }).first()).toBeVisible();
-  await expect(page).toHaveScreenshot('overview.png', {
-    fullPage: true,
-    animations: 'disabled',
-    caret: 'hide',
-  });
+  const screenshot = await page.screenshot({ fullPage: true, animations: 'disabled', caret: 'hide' });
+  await testInfo.attach('overview.png', { body: screenshot, contentType: 'image/png' });
+  const digest = createHash('sha256').update(screenshot).digest('hex');
+  expect(digest).toBe(overviewDigests[testInfo.project.name]);
 });

--- a/e2e/flexdoc.spec.cjs
+++ b/e2e/flexdoc.spec.cjs
@@ -23,12 +23,13 @@ test('desktop search, Try It, response viewer, and code samples work together', 
 
   await page.goto('/e2e/index.html');
   const search = page.getByPlaceholder('Search endpoints...');
+  const sidebar = page.locator('aside').filter({ has: search }).first();
   await search.fill('payload');
-  await expect(page.getByText('/payload', { exact: true })).toBeVisible();
-  await expect(page.getByText('/pets/{id}', { exact: true })).toHaveCount(0);
+  await expect(sidebar.getByText('/payload', { exact: true })).toBeVisible();
+  await expect(sidebar.getByText('/pets/{id}', { exact: true })).toHaveCount(0);
   await search.clear();
 
-  await page.locator('button').filter({ hasText: '/pets/{id}' }).click();
+  await sidebar.locator('button').filter({ hasText: '/pets/{id}' }).click();
   await expect(page).toHaveURL(/#get-pets-id$/);
   await expect(page.getByRole('heading', { name: 'Get a pet' })).toBeVisible();
 

--- a/packages/client/e2e/fixture.tsx
+++ b/packages/client/e2e/fixture.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { FlexDoc } from '../src/components/FlexDoc';
+import { openapi30Spec } from '../src/fixtures/openapi/compatibility';
+
+const spec = JSON.parse(JSON.stringify(openapi30Spec));
+spec.info.title = 'FlexDoc Browser Fixture';
+spec.servers = [
+  { url: 'https://api.example.test', description: 'Primary test server' },
+  { url: 'https://backup.example.test', description: 'Backup test server' },
+];
+spec.paths['/pets/{id}'].get.summary = 'Get a pet';
+spec.paths['/payload'].post.summary = 'Create a payload';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <FlexDoc
+      spec={spec}
+      options={{
+        hideDownloadButton: true,
+        tryIt: { enabled: true },
+        codeSamples: { enabled: true, languages: ['curl', 'javascript', 'python', 'go', 'java'] },
+      }}
+    />
+  </React.StrictMode>,
+);

--- a/packages/client/e2e/index.html
+++ b/packages/client/e2e/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>FlexDoc E2E</title>
+    <style>html,body,#root{margin:0;min-height:100%;}</style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./fixture.tsx"></script>
+  </body>
+</html>

--- a/playwright.config.cjs
+++ b/playwright.config.cjs
@@ -1,0 +1,31 @@
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  fullyParallel: false,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['line'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium-desktop',
+      use: { browserName: 'chromium', viewport: { width: 1440, height: 1000 } },
+    },
+    {
+      name: 'chromium-mobile',
+      use: { browserName: 'chromium', viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev -w packages/client -- --host 127.0.0.1 --port 4173',
+    url: 'http://127.0.0.1:4173/e2e/index.html',
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});


### PR DESCRIPTION
## Summary

Add real-browser validation on top of FlexDoc's OpenAPI compatibility corpus.

## Coverage

- Chromium desktop at 1440×1000
- Chromium mobile at 390×844
- deterministic Vite fixture using the compatibility corpus
- deep links directly into operations
- desktop endpoint search/navigation
- mobile navigation dialog and endpoint selection
- Try It parameter/auth entry
- intercepted request verification (URL, bearer auth and custom headers)
- explicit browser-cookie behavior: the canonical request model can serialize OpenAPI cookie parameters, while browser `fetch` correctly cannot synthesize a forbidden `Cookie` header
- response status/body rendering
- generated JavaScript code samples
- canonical overview visual regression on desktop and mobile

## Visual regression

The canonical screenshots were generated on the same Ubuntu/Chromium CI environment used by this workflow. Their SHA-256 digests are pinned in the Playwright test and every run captures and attaches the current screenshot before comparing its digest. This keeps the visual baseline reviewable as text while still making an unexpected pixel change fail CI.

## CI

The workflow pins `@playwright/test@1.62.1`, installs Chromium, and runs against a local Vite server. API requests are intercepted by Playwright; CI does not depend on an external API service. On failures, traces/screenshots and the HTML report are uploaded as Actions artifacts.

## Dependency

PR #9 (OpenAPI compatibility corpus and support matrix) is merged into `main`; this PR is now based directly on `main`.