### PR TITLE
Add trusted publishing workflow for FlexDoc CLI

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,0 +1,92 @@
+name: Publish CLI to npm Registry
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build-test-and-publish:
+    if: startsWith(github.event.release.tag_name, 'cli/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup build Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install repository dependencies
+        run: npm ci
+
+      - name: Build canonical client renderer
+        run: npm run build:client
+
+      - name: Install CLI dependencies
+        run: npm install --prefix tools/flexdoc-cli --ignore-scripts --no-audit --no-fund
+
+      - name: Test CLI build and serve contracts
+        run: npm test --prefix tools/flexdoc-cli
+        env:
+          FLEXDOC_CLIENT_DIR: ${{ github.workspace }}/packages/client
+
+      - name: Verify CLI release tag matches package version
+        run: |
+          VERSION=$(node -p "require('./tools/flexdoc-cli/package.json').version")
+          test "${{ github.event.release.tag_name }}" = "cli/v${VERSION}"
+
+      - name: Pack CLI artifact
+        run: |
+          mkdir -p cli-release
+          cd tools/flexdoc-cli
+          npm pack --pack-destination "${GITHUB_WORKSPACE}/cli-release"
+
+      - name: Verify packed CLI from a clean consumer
+        run: |
+          TAR=$(find "${GITHUB_WORKSPACE}/cli-release" -maxdepth 1 -name '*.tgz' -print -quit)
+          test -n "$TAR"
+          test "$(tar -tzf "$TAR" | grep -c '^package/bin/flexdoc.js$')" = "1"
+          test "$(tar -tzf "$TAR" | grep -c '^package/src/cli.js$')" = "1"
+          test "$(tar -tzf "$TAR" | grep -c '^package/package.json$')" = "1"
+
+          CONSUMER=$(mktemp -d)
+          cd "$CONSUMER"
+          npm init -y >/dev/null 2>&1
+          npm install "$TAR" --ignore-scripts --no-audit --no-fund
+
+          EXPECTED_VERSION=$(node -p "require('${GITHUB_WORKSPACE}/tools/flexdoc-cli/package.json').version")
+          test "$(./node_modules/.bin/flexdoc --version)" = "$EXPECTED_VERSION"
+
+          ./node_modules/.bin/flexdoc build \
+            "${GITHUB_WORKSPACE}/tools/flexdoc-cli/test/fixtures/openapi.yaml" \
+            --out ./site \
+            --base-path /docs/
+
+          test -f site/index.html
+          test -f site/flexdoc.js
+          test -f site/flexdoc.css
+          test -f site/openapi.json
+          node -e "const s=require('./site/openapi.json'); if (!s['x-flexdoc-external-documents'] || Object.keys(s['x-flexdoc-external-documents']).length !== 2) process.exit(1)"
+
+      - name: Setup publishing Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org/'
+          package-manager-cache: false
+
+      - name: Ensure trusted-publishing capable npm
+        run: npm install --global npm@^11.15.0
+
+      - name: Inspect npm package contents
+        run: npm pack --dry-run --prefix tools/flexdoc-cli
+
+      - name: Publish CLI through npm Trusted Publishing
+        working-directory: tools/flexdoc-cli
+        run: npm publish --access public

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Browser-side loading of cross-origin external OpenAPI references is subject to t
 | --- | --- | --- |
 | `@bluejeans/flexdoc-client` | `2.0.2` | React components plus the canonical standalone renderer |
 | `@bluejeans/flexdoc-backend` | `2.0.2` | Thin Express, Fastify and NestJS integrations |
-| `@bluejeans/flexdoc-cli` | `0.1.0` source | CLI serving/static export; npm publication follows this change |
+| `@bluejeans/flexdoc-cli` | `0.1.0` source | CLI serving/static export; npm release workflow is prepared |
 | `io.github.bluejeans117.flexdoc:flexdoc-spring-boot-starter` | `0.1.0` | Spring Boot adapter published on Maven Central |
 
 Language adapters have independent ecosystem versions. Compatibility is governed by the renderer contract rather than forcing npm, Maven, PyPI, crates.io and Go modules to share one version number. See [Distribution and versioning](./docs/distribution.md).
@@ -55,6 +55,8 @@ npx @bluejeans/flexdoc-cli build openapi.yaml --out ./docs
 ```
 
 The static export contains `index.html`, `flexdoc.js`, `flexdoc.css`, and a bundled `openapi.json`. External `$ref` documents are resolved and bundled at build time, so the deployed site does not need the original external spec files. Use `--base-path /repository-name/` for GitHub Pages project sites or other sub-path deployments.
+
+The CLI has an independent `0.x` release line. Once the package is bootstrapped on npm and its Trusted Publisher is configured, GitHub Releases named `cli/v<version>` publish it through `.github/workflows/publish-cli.yml`. The workflow validates the tag, tests the CLI, installs the packed tarball into a clean consumer, exercises an actual static build, and then publishes with GitHub OIDC.
 
 ## React
 
@@ -179,7 +181,7 @@ The JavaScript renderer/backend packages are released as a coordinated `2.x` lin
 
 Publication credentials must never be committed to this repository. npm, Maven Central, PyPI and other registry credentials/trusted-publishing configuration belong in the registry and GitHub Actions environment configuration.
 
-See [Distribution and versioning](./docs/distribution.md) for the release model, Maven Central setup, and the planned Python/Rust/Go distribution paths.
+See [Distribution and versioning](./docs/distribution.md) for the release model, CLI publishing, Maven Central setup, and the planned Python/Rust/Go distribution paths.
 
 ## Documentation
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -10,20 +10,22 @@ The renderer contract is the compatibility boundary between the shared browser p
 | --- | --- | --- |
 | `@bluejeans/flexdoc-client` | `2.x` | canonical renderer; renderer contract v1 |
 | `@bluejeans/flexdoc-backend` | `2.x` | packages the matching 2.x standalone renderer; contract v1 |
+| `@bluejeans/flexdoc-cli` | `0.x` initially | consumes a compatible FlexDoc 2.x client and renderer contract v1 |
 | Spring Boot starter | `0.1.x` initially | renderer contract v1 / FlexDoc renderer 2.x |
 | Python adapter | future independent version | declare supported renderer contract |
 | Rust adapter | future independent version | declare supported renderer contract |
 | Go adapter | future independent module version | declare supported renderer contract |
 
-Do not synchronize versions across registries merely for aesthetics. Existing npm packages have release history, while a new Maven artifact does not. Instead, CI and package documentation must make renderer-contract compatibility explicit.
+Do not synchronize versions across registries merely for aesthetics. Existing npm packages have release history, while new ecosystem artifacts do not. Instead, CI and package documentation must make renderer-contract compatibility explicit.
 
 A breaking renderer-contract change requires a new contract major. An adapter can evolve independently while it continues to consume the same contract.
 
 ## Release tags
 
-Registry releases are intentionally scoped by ecosystem so independent adapter versions do not trigger unrelated publishers:
+Registry releases are intentionally scoped by ecosystem/package family so independent versions do not trigger unrelated publishers:
 
 - `js/v<version>` publishes the coordinated npm client/backend release;
+- `cli/v<version>` publishes `@bluejeans/flexdoc-cli`;
 - `java/v<version>` publishes the Spring Boot adapter to Maven Central.
 
 Future adapters should use an equivalent ecosystem-specific tag family when they gain automated publishing.
@@ -34,12 +36,13 @@ The npm packages are public scoped packages:
 
 - `@bluejeans/flexdoc-client`
 - `@bluejeans/flexdoc-backend`
+- `@bluejeans/flexdoc-cli`
 
-For the consolidated renderer architecture, both packages move to `2.0.0`.
+The client/backend stay on a coordinated `2.x` line because the backend packages the canonical renderer. The CLI has its own `0.x` line and declares a compatible client dependency.
 
-The release workflows use npm Trusted Publishing through GitHub OIDC. No long-lived `NPM_TOKEN` is required. The trusted-publisher relationship on npmjs.com must point to the exact GitHub repository and workflow filename for each package.
+The release workflows use npm Trusted Publishing through GitHub OIDC. No long-lived `NPM_TOKEN` is required after the trusted-publisher relationship exists. The trusted-publisher relationship on npmjs.com must point to the exact GitHub repository and workflow filename for each package.
 
-Release policy:
+### Client/backend release policy
 
 1. merge only after client/backend tests, standalone build checks, contract validation, backend asset checks and Java verification are green;
 2. create an immutable `js/v<version>` Git tag/GitHub Release;
@@ -48,7 +51,31 @@ Release policy:
 5. publish using npm Trusted Publishing;
 6. never rewrite a registry version. Fixes receive a new patch version.
 
-The two npm packages should remain on the same 2.x version for now because the backend vendors the canonical client renderer and coordinated versions make that relationship obvious.
+The two coordinated npm packages should remain on the same 2.x version for now because the backend vendors the canonical client renderer and coordinated versions make that relationship obvious.
+
+### CLI release policy
+
+The CLI uses `.github/workflows/publish-cli.yml` and `cli/v<version>` GitHub Releases.
+
+Before publication the workflow:
+
+1. builds the canonical client renderer used by the CLI;
+2. runs the CLI build/serve contract tests;
+3. validates the GitHub Release tag exactly matches `tools/flexdoc-cli/package.json`;
+4. packs the CLI tarball;
+5. installs that tarball into a clean temporary npm consumer;
+6. verifies the installed `flexdoc` binary reports the expected version;
+7. builds the nested external-reference fixture through the installed tarball and checks the generated static site/bundled spec;
+8. switches to the current Trusted-Publishing-capable npm/Node toolchain and publishes through OIDC.
+
+The first npm publication may require a one-time registry-side bootstrap before npm allows configuring Trusted Publishing for the new package. After that bootstrap, configure the Trusted Publisher for:
+
+- repository owner: `bluejeans117`;
+- repository: `flexdoc`;
+- workflow filename: `publish-cli.yml`;
+- publication permission: `npm publish`.
+
+Do not create a GitHub Release for a registry version that was already manually bootstrap-published, because npm package versions are immutable and the workflow would attempt to republish the same version.
 
 ## Maven Central / Spring Boot
 


### PR DESCRIPTION
## Summary

Prepare `@bluejeans/flexdoc-cli` for repeatable npm releases after the one-time npm-side bootstrap/Trusted Publisher setup.

## Release model

- GitHub Release tags: `cli/v<version>`
- package version source: `tools/flexdoc-cli/package.json`
- exact tag/version validation before publication
- dedicated `.github/workflows/publish-cli.yml`
- npm Trusted Publishing / GitHub OIDC (`id-token: write`)
- no `NPM_TOKEN`

## Release validation

Before publishing, the workflow:

1. installs repository dependencies;
2. builds the canonical FlexDoc client/standalone renderer;
3. installs and tests the CLI package;
4. validates `cli/v<version>` against the committed CLI version;
5. creates the actual CLI tarball;
6. installs that tarball into a fresh temporary npm consumer;
7. verifies the installed `flexdoc --version` output;
8. builds the nested external-reference CLI fixture through the installed package;
9. verifies the generated static site and bundled external documents;
10. switches to Node 24 / npm 11.15+ and publishes through Trusted Publishing.

## Documentation

Update the root README and distribution guide with the independent CLI `0.x` release line, `cli/v...` tags, workflow filename, and one-time npm bootstrap boundary.

## npm-side action

This PR intentionally does not attempt registry configuration. After merge, the package can be bootstrap-published/configured on npm, then future versions are released through GitHub Releases and this workflow.