### PR TITLE
Add standalone API client foundation

### DIFF
--- a/core/src/http-client.ts
+++ b/core/src/http-client.ts
@@ -84,8 +84,10 @@ export function buildHttpRequest(draft: HttpRequestDraft): BuiltRequest {
   if (draft.body && !['GET', 'HEAD'].includes(method)) {
     body = draft.body;
     requestBody = draft.body;
-    const contentType = draft.contentType?.trim();
-    if (contentType && !findHeader(headers, 'Content-Type')) setHeader(headers, 'Content-Type', contentType);
+    const explicitContentType = findHeader(headers, 'Content-Type');
+    const requestedContentType = draft.contentType?.trim();
+    if (!explicitContentType && requestedContentType) setHeader(headers, 'Content-Type', requestedContentType);
+    const contentType = explicitContentType || requestedContentType;
     bodyKind = contentType?.includes('json') ? 'json' : contentType === 'application/x-www-form-urlencoded' ? 'form' : contentType?.startsWith('multipart/form-data') ? 'multipart' : 'text';
   }
 

--- a/core/src/http-client.ts
+++ b/core/src/http-client.ts
@@ -1,0 +1,112 @@
+import type { BuiltRequest } from './request-builder.js';
+
+export interface HttpKeyValue {
+  key: string;
+  value: string;
+  enabled?: boolean;
+}
+
+export type HttpAuth =
+  | { type: 'none' }
+  | { type: 'bearer'; token: string }
+  | { type: 'basic'; username: string; password: string }
+  | { type: 'apiKey'; key: string; value: string; in: 'header' | 'query' };
+
+export interface HttpRequestDraft {
+  method: string;
+  url: string;
+  query?: HttpKeyValue[];
+  headers?: HttpKeyValue[];
+  body?: string;
+  contentType?: string;
+  auth?: HttpAuth;
+}
+
+function enabledPairs(entries: HttpKeyValue[] | undefined): HttpKeyValue[] {
+  return (entries || []).filter((entry) => entry.enabled !== false && entry.key.trim() !== '');
+}
+
+function appendQuery(url: string, entries: HttpKeyValue[]): string {
+  if (!entries.length) return url;
+  const hashIndex = url.indexOf('#');
+  const base = hashIndex >= 0 ? url.slice(0, hashIndex) : url;
+  const fragment = hashIndex >= 0 ? url.slice(hashIndex) : '';
+  const encoded = entries.map(({ key, value }) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`).join('&');
+  const separator = base.includes('?') ? (base.endsWith('?') || base.endsWith('&') ? '' : '&') : '?';
+  return `${base}${separator}${encoded}${fragment}`;
+}
+
+function findHeader(headers: Record<string, string>, name: string): string | undefined {
+  const key = Object.keys(headers).find((candidate) => candidate.toLowerCase() === name.toLowerCase());
+  return key ? headers[key] : undefined;
+}
+
+function setHeader(headers: Record<string, string>, name: string, value: string): void {
+  const existing = Object.keys(headers).find((candidate) => candidate.toLowerCase() === name.toLowerCase());
+  if (existing && existing !== name) delete headers[existing];
+  headers[name] = value;
+}
+
+function encodeBasicCredential(value: string): string {
+  if (typeof globalThis.btoa === 'function') return globalThis.btoa(unescape(encodeURIComponent(value)));
+  return value;
+}
+
+function applyAuth(draft: HttpRequestDraft, headers: Record<string, string>, query: HttpKeyValue[]): void {
+  const auth = draft.auth;
+  if (!auth || auth.type === 'none') return;
+  if (auth.type === 'bearer') {
+    if (auth.token) setHeader(headers, 'Authorization', `Bearer ${auth.token}`);
+    return;
+  }
+  if (auth.type === 'basic') {
+    if (auth.username || auth.password) setHeader(headers, 'Authorization', `Basic ${encodeBasicCredential(`${auth.username}:${auth.password}`)}`);
+    return;
+  }
+  if (!auth.key) return;
+  if (auth.in === 'query') query.push({ key: auth.key, value: auth.value });
+  else setHeader(headers, auth.key, auth.value);
+}
+
+export function buildHttpRequest(draft: HttpRequestDraft): BuiltRequest {
+  const method = (draft.method || 'GET').trim().toUpperCase();
+  const url = draft.url.trim();
+  if (!url) throw new Error('Request URL is required.');
+
+  const query = enabledPairs(draft.query);
+  const headers: Record<string, string> = {};
+  for (const entry of enabledPairs(draft.headers)) setHeader(headers, entry.key, entry.value);
+  applyAuth(draft, headers, query);
+
+  let body: string | undefined;
+  let bodyKind: BuiltRequest['bodyKind'];
+  let requestBody: BodyInit | undefined;
+  if (draft.body && !['GET', 'HEAD'].includes(method)) {
+    body = draft.body;
+    requestBody = draft.body;
+    const contentType = draft.contentType?.trim();
+    if (contentType && !findHeader(headers, 'Content-Type')) setHeader(headers, 'Content-Type', contentType);
+    bodyKind = contentType?.includes('json') ? 'json' : contentType === 'application/x-www-form-urlencoded' ? 'form' : contentType?.startsWith('multipart/form-data') ? 'multipart' : 'text';
+  }
+
+  const resolvedUrl = appendQuery(url, query);
+  return {
+    url: resolvedUrl,
+    method,
+    headers,
+    body,
+    bodyKind,
+    init: { method, headers, body: requestBody },
+  };
+}
+
+export function requestDraftFromBuiltRequest(request: BuiltRequest): HttpRequestDraft {
+  return {
+    method: request.method,
+    url: request.url,
+    headers: Object.entries(request.headers).map(([key, value]) => ({ key, value })),
+    body: request.body,
+    contentType: findHeader(request.headers, 'Content-Type'),
+    auth: { type: 'none' },
+  };
+}

--- a/core/src/http-client.ts
+++ b/core/src/http-client.ts
@@ -46,6 +46,23 @@ function appendQuery(url: string, entries: HttpKeyValue[]): string {
   return `${base}${separator}${encoded}${fragment}`;
 }
 
+function splitQuery(url: string): { url: string; query: HttpKeyValue[] } {
+  const hashIndex = url.indexOf('#');
+  const beforeFragment = hashIndex >= 0 ? url.slice(0, hashIndex) : url;
+  const fragment = hashIndex >= 0 ? url.slice(hashIndex) : '';
+  const queryIndex = beforeFragment.indexOf('?');
+  if (queryIndex < 0) return { url, query: [] };
+
+  const query: HttpKeyValue[] = [];
+  const search = new URLSearchParams(beforeFragment.slice(queryIndex + 1));
+  search.forEach((value, key) => query.push({ key, value }));
+
+  return {
+    url: `${beforeFragment.slice(0, queryIndex)}${fragment}`,
+    query,
+  };
+}
+
 function findHeader(entries: Array<[string, string]>, name: string): string | undefined {
   return entries.find(([candidate]) => candidate.toLowerCase() === name.toLowerCase())?.[1];
 }
@@ -129,9 +146,11 @@ export function buildHttpRequest(draft: HttpRequestDraft): HttpBuiltRequest {
 
 export function requestDraftFromBuiltRequest(request: BuiltRequest & { headerEntries?: Array<[string, string]> }): HttpRequestDraft {
   const entries = request.headerEntries || Object.entries(request.headers);
+  const split = splitQuery(request.url);
   return {
     method: request.method,
-    url: request.url,
+    url: split.url,
+    query: split.query,
     headers: entries.map(([key, value]) => ({ key, value })),
     body: request.body,
     contentType: findHeader(entries, 'Content-Type'),

--- a/core/src/http-client.ts
+++ b/core/src/http-client.ts
@@ -22,6 +22,16 @@ export interface HttpRequestDraft {
   auth?: HttpAuth;
 }
 
+/**
+ * Arbitrary HTTP requests retain their ordered header entries in addition to
+ * the legacy record view exposed by BuiltRequest. The ordered entries are the
+ * canonical representation for execution because a record cannot represent
+ * duplicate header names.
+ */
+export interface HttpBuiltRequest extends BuiltRequest {
+  headerEntries: Array<[string, string]>;
+}
+
 function enabledPairs(entries: HttpKeyValue[] | undefined): HttpKeyValue[] {
   return (entries || []).filter((entry) => entry.enabled !== false && entry.key.trim() !== '');
 }
@@ -36,47 +46,60 @@ function appendQuery(url: string, entries: HttpKeyValue[]): string {
   return `${base}${separator}${encoded}${fragment}`;
 }
 
-function findHeader(headers: Record<string, string>, name: string): string | undefined {
-  const key = Object.keys(headers).find((candidate) => candidate.toLowerCase() === name.toLowerCase());
-  return key ? headers[key] : undefined;
+function findHeader(entries: Array<[string, string]>, name: string): string | undefined {
+  return entries.find(([candidate]) => candidate.toLowerCase() === name.toLowerCase())?.[1];
 }
 
-function setHeader(headers: Record<string, string>, name: string, value: string): void {
-  const existing = Object.keys(headers).find((candidate) => candidate.toLowerCase() === name.toLowerCase());
-  if (existing && existing !== name) delete headers[existing];
-  headers[name] = value;
+function replaceHeader(entries: Array<[string, string]>, name: string, value: string): void {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    if (entries[index][0].toLowerCase() === name.toLowerCase()) entries.splice(index, 1);
+  }
+  entries.push([name, value]);
+}
+
+function headerRecord(entries: Array<[string, string]>): Record<string, string> {
+  const headers: Record<string, string> = {};
+  for (const [name, value] of entries) headers[name] = value;
+  return headers;
 }
 
 function encodeBasicCredential(value: string): string {
-  if (typeof globalThis.btoa === 'function') return globalThis.btoa(unescape(encodeURIComponent(value)));
-  return value;
+  if (typeof globalThis.btoa === 'function') {
+    if (typeof TextEncoder === 'undefined') throw new Error('Basic auth requires UTF-8 encoding support.');
+    const bytes = new TextEncoder().encode(value);
+    let binary = '';
+    for (const byte of bytes) binary += String.fromCharCode(byte);
+    return globalThis.btoa(binary);
+  }
+  const BufferCtor = (globalThis as any).Buffer;
+  if (BufferCtor?.from) return BufferCtor.from(value, 'utf8').toString('base64');
+  throw new Error('Basic auth requires a Base64 encoder in this runtime.');
 }
 
-function applyAuth(draft: HttpRequestDraft, headers: Record<string, string>, query: HttpKeyValue[]): void {
+function applyAuth(draft: HttpRequestDraft, headers: Array<[string, string]>, query: HttpKeyValue[]): void {
   const auth = draft.auth;
   if (!auth || auth.type === 'none') return;
   if (auth.type === 'bearer') {
-    if (auth.token) setHeader(headers, 'Authorization', `Bearer ${auth.token}`);
+    if (auth.token) replaceHeader(headers, 'Authorization', `Bearer ${auth.token}`);
     return;
   }
   if (auth.type === 'basic') {
-    if (auth.username || auth.password) setHeader(headers, 'Authorization', `Basic ${encodeBasicCredential(`${auth.username}:${auth.password}`)}`);
+    if (auth.username || auth.password) replaceHeader(headers, 'Authorization', `Basic ${encodeBasicCredential(`${auth.username}:${auth.password}`)}`);
     return;
   }
   if (!auth.key) return;
   if (auth.in === 'query') query.push({ key: auth.key, value: auth.value });
-  else setHeader(headers, auth.key, auth.value);
+  else replaceHeader(headers, auth.key, auth.value);
 }
 
-export function buildHttpRequest(draft: HttpRequestDraft): BuiltRequest {
+export function buildHttpRequest(draft: HttpRequestDraft): HttpBuiltRequest {
   const method = (draft.method || 'GET').trim().toUpperCase();
   const url = draft.url.trim();
   if (!url) throw new Error('Request URL is required.');
 
   const query = enabledPairs(draft.query);
-  const headers: Record<string, string> = {};
-  for (const entry of enabledPairs(draft.headers)) setHeader(headers, entry.key, entry.value);
-  applyAuth(draft, headers, query);
+  const headerEntries: Array<[string, string]> = enabledPairs(draft.headers).map(({ key, value }) => [key, value]);
+  applyAuth(draft, headerEntries, query);
 
   let body: string | undefined;
   let bodyKind: BuiltRequest['bodyKind'];
@@ -84,31 +107,34 @@ export function buildHttpRequest(draft: HttpRequestDraft): BuiltRequest {
   if (draft.body && !['GET', 'HEAD'].includes(method)) {
     body = draft.body;
     requestBody = draft.body;
-    const explicitContentType = findHeader(headers, 'Content-Type');
+    const explicitContentType = findHeader(headerEntries, 'Content-Type');
     const requestedContentType = draft.contentType?.trim();
-    if (!explicitContentType && requestedContentType) setHeader(headers, 'Content-Type', requestedContentType);
+    if (!explicitContentType && requestedContentType) headerEntries.push(['Content-Type', requestedContentType]);
     const contentType = explicitContentType || requestedContentType;
     bodyKind = contentType?.includes('json') ? 'json' : contentType === 'application/x-www-form-urlencoded' ? 'form' : contentType?.startsWith('multipart/form-data') ? 'multipart' : 'text';
   }
 
+  const headers = headerRecord(headerEntries);
   const resolvedUrl = appendQuery(url, query);
   return {
     url: resolvedUrl,
     method,
     headers,
+    headerEntries,
     body,
     bodyKind,
-    init: { method, headers, body: requestBody },
+    init: { method, headers: headerEntries, body: requestBody },
   };
 }
 
-export function requestDraftFromBuiltRequest(request: BuiltRequest): HttpRequestDraft {
+export function requestDraftFromBuiltRequest(request: BuiltRequest & { headerEntries?: Array<[string, string]> }): HttpRequestDraft {
+  const entries = request.headerEntries || Object.entries(request.headers);
   return {
     method: request.method,
     url: request.url,
-    headers: Object.entries(request.headers).map(([key, value]) => ({ key, value })),
+    headers: entries.map(([key, value]) => ({ key, value })),
     body: request.body,
-    contentType: findHeader(request.headers, 'Content-Type'),
+    contentType: findHeader(entries, 'Content-Type'),
     auth: { type: 'none' },
   };
 }

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -6,5 +6,7 @@ export { normalizeOperation, resolveObject, resolvePathItem, resolveServerVariab
 export type { NormalizedOperation } from './openapi-normalizer.js';
 export { buildRequest, initialRequestValues, operationFor, parametersFor } from './request-builder.js';
 export type { BuiltRequest, RequestValue, RequestValues } from './request-builder.js';
+export { buildHttpRequest, requestDraftFromBuiltRequest } from './http-client.js';
+export type { HttpAuth, HttpKeyValue, HttpRequestDraft } from './http-client.js';
 export { generateCodeSample, languageLabel } from './code-samples.js';
 export type { CodeSampleLanguage } from './code-samples.js';

--- a/core/test/http-client.test.mjs
+++ b/core/test/http-client.test.mjs
@@ -83,3 +83,28 @@ test('round-trips a built request into an editable draft without losing duplicat
     { key: 'Content-Type', value: 'application/json' },
   ]);
 });
+
+test('round-trips ordered duplicate query parameters without duplicating them on rebuild', () => {
+  const built = buildHttpRequest({
+    method: 'GET',
+    url: 'https://api.example.test/pets#results',
+    query: [
+      { key: 'limit', value: '10' },
+      { key: 'limit', value: '20' },
+      { key: 'search', value: 'red fox' },
+      { key: 'empty', value: '' },
+    ],
+  });
+
+  const draft = requestDraftFromBuiltRequest(built);
+  assert.equal(draft.url, 'https://api.example.test/pets#results');
+  assert.deepEqual(draft.query, [
+    { key: 'limit', value: '10' },
+    { key: 'limit', value: '20' },
+    { key: 'search', value: 'red fox' },
+    { key: 'empty', value: '' },
+  ]);
+
+  const rebuilt = buildHttpRequest(draft);
+  assert.equal(rebuilt.url, built.url);
+});

--- a/core/test/http-client.test.mjs
+++ b/core/test/http-client.test.mjs
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { buildHttpRequest, requestDraftFromBuiltRequest } from '../dist/index.js';
+
+test('builds arbitrary HTTP requests with duplicate query params and headers', () => {
+  const request = buildHttpRequest({
+    method: 'post',
+    url: 'https://api.example.test/search?existing=1#frag',
+    query: [
+      { key: 'tag', value: 'one' },
+      { key: 'tag', value: 'two' },
+      { key: 'skip', value: 'x', enabled: false },
+    ],
+    headers: [
+      { key: 'X-Trace', value: 'abc' },
+      { key: 'Content-Type', value: 'application/json' },
+    ],
+    body: '{"ok":true}',
+    contentType: 'text/plain',
+  });
+
+  assert.equal(request.method, 'POST');
+  assert.equal(request.url, 'https://api.example.test/search?existing=1&tag=one&tag=two#frag');
+  assert.equal(request.headers['X-Trace'], 'abc');
+  assert.equal(request.headers['Content-Type'], 'application/json');
+  assert.equal(request.bodyKind, 'json');
+  assert.equal(request.body, '{"ok":true}');
+});
+
+test('applies common auth without coupling to OpenAPI', () => {
+  const bearer = buildHttpRequest({ method: 'GET', url: 'https://api.example.test/pets', auth: { type: 'bearer', token: 'secret' } });
+  assert.equal(bearer.headers.Authorization, 'Bearer secret');
+
+  const apiKey = buildHttpRequest({
+    method: 'GET',
+    url: 'https://api.example.test/pets',
+    auth: { type: 'apiKey', key: 'api_key', value: '123', in: 'query' },
+  });
+  assert.equal(apiKey.url, 'https://api.example.test/pets?api_key=123');
+});
+
+test('round-trips a built request into an editable draft', () => {
+  const built = buildHttpRequest({
+    method: 'PATCH',
+    url: 'https://api.example.test/pets/42',
+    headers: [{ key: 'Content-Type', value: 'application/json' }],
+    body: '{"name":"Mochi"}',
+  });
+  const draft = requestDraftFromBuiltRequest(built);
+  assert.equal(draft.method, 'PATCH');
+  assert.equal(draft.url, built.url);
+  assert.equal(draft.contentType, 'application/json');
+  assert.deepEqual(draft.headers, [{ key: 'Content-Type', value: 'application/json' }]);
+});

--- a/core/test/http-client.test.mjs
+++ b/core/test/http-client.test.mjs
@@ -13,6 +13,7 @@ test('builds arbitrary HTTP requests with duplicate query params and headers', (
     ],
     headers: [
       { key: 'X-Trace', value: 'abc' },
+      { key: 'X-Trace', value: 'def' },
       { key: 'Content-Type', value: 'application/json' },
     ],
     body: '{"ok":true}',
@@ -21,7 +22,13 @@ test('builds arbitrary HTTP requests with duplicate query params and headers', (
 
   assert.equal(request.method, 'POST');
   assert.equal(request.url, 'https://api.example.test/search?existing=1&tag=one&tag=two#frag');
-  assert.equal(request.headers['X-Trace'], 'abc');
+  assert.deepEqual(request.headerEntries, [
+    ['X-Trace', 'abc'],
+    ['X-Trace', 'def'],
+    ['Content-Type', 'application/json'],
+  ]);
+  assert.deepEqual(request.init.headers, request.headerEntries);
+  assert.equal(request.headers['X-Trace'], 'def');
   assert.equal(request.headers['Content-Type'], 'application/json');
   assert.equal(request.bodyKind, 'json');
   assert.equal(request.body, '{"ok":true}');
@@ -39,16 +46,40 @@ test('applies common auth without coupling to OpenAPI', () => {
   assert.equal(apiKey.url, 'https://api.example.test/pets?api_key=123');
 });
 
-test('round-trips a built request into an editable draft', () => {
+test('uses a real Base64 fallback for Basic auth when btoa is unavailable', () => {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'btoa');
+  Object.defineProperty(globalThis, 'btoa', { value: undefined, configurable: true });
+  try {
+    const request = buildHttpRequest({
+      method: 'GET',
+      url: 'https://api.example.test/pets',
+      auth: { type: 'basic', username: 'alice', password: 'sëcret' },
+    });
+    assert.equal(request.headers.Authorization, `Basic ${Buffer.from('alice:sëcret', 'utf8').toString('base64')}`);
+  } finally {
+    if (descriptor) Object.defineProperty(globalThis, 'btoa', descriptor);
+    else delete globalThis.btoa;
+  }
+});
+
+test('round-trips a built request into an editable draft without losing duplicate headers', () => {
   const built = buildHttpRequest({
     method: 'PATCH',
     url: 'https://api.example.test/pets/42',
-    headers: [{ key: 'Content-Type', value: 'application/json' }],
+    headers: [
+      { key: 'X-Trace', value: 'one' },
+      { key: 'X-Trace', value: 'two' },
+      { key: 'Content-Type', value: 'application/json' },
+    ],
     body: '{"name":"Mochi"}',
   });
   const draft = requestDraftFromBuiltRequest(built);
   assert.equal(draft.method, 'PATCH');
   assert.equal(draft.url, built.url);
   assert.equal(draft.contentType, 'application/json');
-  assert.deepEqual(draft.headers, [{ key: 'Content-Type', value: 'application/json' }]);
+  assert.deepEqual(draft.headers, [
+    { key: 'X-Trace', value: 'one' },
+    { key: 'X-Trace', value: 'two' },
+    { key: 'Content-Type', value: 'application/json' },
+  ]);
 });

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -21,6 +21,28 @@ function ApiDocumentation() {
 }
 ```
 
+### Standalone API Client
+
+`ApiClient` can execute arbitrary HTTP requests without requiring an OpenAPI document. It uses the same canonical request shape as FlexDoc's OpenAPI request builder and code-sample generator.
+
+```jsx
+import { ApiClient } from '@prauga/flexdoc-client';
+
+function RequestWorkspace() {
+  return (
+    <ApiClient
+      initialRequest={{
+        method: 'GET',
+        url: 'https://api.example.com/pets',
+        query: [{ key: 'limit', value: '10' }],
+      }}
+    />
+  );
+}
+```
+
+For programmatic request construction, `buildHttpRequest` accepts arbitrary methods, URLs, ordered query parameters and headers, bodies, and common authorization modes. `requestDraftFromBuiltRequest` converts an existing canonical FlexDoc request into an editable API-client draft.
+
 ### With Custom Styling
 
 ```jsx

--- a/packages/client/src/components/ApiClient.test.tsx
+++ b/packages/client/src/components/ApiClient.test.tsx
@@ -33,7 +33,6 @@ describe('ApiClient', () => {
       credentials: 'same-origin',
       headers: { 'Content-Type': 'application/json' },
     }));
-    expect(await screen.findByText(/201 Created/)).toBeInTheDocument();
   });
 
   it('supports query parameters and bearer authorization', async () => {

--- a/packages/client/src/components/ApiClient.test.tsx
+++ b/packages/client/src/components/ApiClient.test.tsx
@@ -89,8 +89,8 @@ describe('ApiClient', () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(second).not.toHaveBeenCalled();
 
-    fireEvent.change(screen.getByLabelText('Request URL'), { target: { value: 'https://api.example.test/users' } });
+    fireEvent.change(screen.getByLabelText('HTTP method'), { target: { value: 'POST' } });
     await waitFor(() => expect(second).toHaveBeenCalledTimes(1));
-    expect(second.mock.calls[0][0]).toEqual(expect.objectContaining({ url: 'https://api.example.test/users' }));
+    expect(second.mock.calls[0][0]).toEqual(expect.objectContaining({ method: 'POST' }));
   });
 });

--- a/packages/client/src/components/ApiClient.test.tsx
+++ b/packages/client/src/components/ApiClient.test.tsx
@@ -1,3 +1,4 @@
+import React, { useState } from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { ApiClient } from './ApiClient';
@@ -27,12 +28,30 @@ describe('ApiClient', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Send request' }));
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
-    expect(fetchMock).toHaveBeenCalledWith('https://api.example.test/pets', expect.objectContaining({
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init).toEqual(expect.objectContaining({
       method: 'POST',
       body: '{"name":"Mochi"}',
       credentials: 'same-origin',
-      headers: { 'Content-Type': 'application/json' },
     }));
+    expect(init.headers).toEqual([['Content-Type', 'application/json']]);
+  });
+
+  it('preserves duplicate headers when executing requests', async () => {
+    fetchMock.mockResolvedValue({ status: 200, statusText: 'OK', headers: new Headers(), text: async () => '' });
+    render(<ApiClient initialRequest={{
+      method: 'GET',
+      url: 'https://api.example.test/pets',
+      headers: [
+        { key: 'X-Trace', value: 'one' },
+        { key: 'X-Trace', value: 'two' },
+      ],
+    }} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Send request' }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers).toEqual([['X-Trace', 'one'], ['X-Trace', 'two']]);
   });
 
   it('supports query parameters and bearer authorization', async () => {
@@ -51,7 +70,7 @@ describe('ApiClient', () => {
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toBe('https://api.example.test/pets?limit=10');
-    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer secret');
+    expect(init.headers).toContainEqual(['Authorization', 'Bearer secret']);
   });
 
   it('reports the current canonical built request to consumers', async () => {
@@ -59,5 +78,22 @@ describe('ApiClient', () => {
     render(<ApiClient initialRequest={{ method: 'GET', url: 'https://api.example.test/pets' }} onRequestChange={onRequestChange} />);
     await waitFor(() => expect(onRequestChange).toHaveBeenCalled());
     expect(onRequestChange.mock.calls.at(-1)?.[0]).toEqual(expect.objectContaining({ method: 'GET', url: 'https://api.example.test/pets' }));
+  });
+
+  it('does not loop when an inline request-change callback updates parent state', async () => {
+    let renders = 0;
+    const Parent = () => {
+      const [, setLatest] = useState<unknown>(null);
+      renders += 1;
+      return <ApiClient
+        initialRequest={{ method: 'GET', url: 'https://api.example.test/pets' }}
+        onRequestChange={(request) => setLatest(request)}
+      />;
+    };
+
+    render(<Parent />);
+    await waitFor(() => expect(renders).toBeGreaterThan(1));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(renders).toBeLessThan(5);
   });
 });

--- a/packages/client/src/components/ApiClient.test.tsx
+++ b/packages/client/src/components/ApiClient.test.tsx
@@ -18,8 +18,12 @@ describe('ApiClient', () => {
       text: async () => '{"id":42}',
     });
 
-    render(<ApiClient initialRequest={{ method: 'POST', url: 'https://api.example.test/pets' }} />);
-    fireEvent.change(screen.getByLabelText('Request body'), { target: { value: '{"name":"Mochi"}' } });
+    render(<ApiClient initialRequest={{
+      method: 'POST',
+      url: 'https://api.example.test/pets',
+      body: '{"name":"Mochi"}',
+      contentType: 'application/json',
+    }} />);
     fireEvent.click(screen.getByRole('button', { name: 'Send request' }));
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
@@ -27,18 +31,22 @@ describe('ApiClient', () => {
       method: 'POST',
       body: '{"name":"Mochi"}',
       credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
     }));
     expect(await screen.findByText(/201 Created/)).toBeInTheDocument();
   });
 
   it('supports query parameters and bearer authorization', async () => {
     fetchMock.mockResolvedValue({ status: 200, statusText: 'OK', headers: new Headers(), text: async () => '' });
-    render(<ApiClient initialRequest={{ url: 'https://api.example.test/pets' }} />);
+    render(<ApiClient initialRequest={{
+      method: 'GET',
+      url: 'https://api.example.test/pets',
+      query: [{ key: 'limit', value: '10' }],
+      auth: { type: 'bearer', token: 'secret' },
+    }} />);
 
-    fireEvent.change(screen.getByLabelText('Query parameters 1 key'), { target: { value: 'limit' } });
-    fireEvent.change(screen.getByLabelText('Query parameters 1 value'), { target: { value: '10' } });
-    fireEvent.change(screen.getByLabelText('Authorization type'), { target: { value: 'bearer' } });
-    fireEvent.change(screen.getByLabelText('Bearer token'), { target: { value: 'secret' } });
+    expect(screen.getByLabelText('Query parameters 1 key')).toHaveValue('limit');
+    expect(screen.getByLabelText('Query parameters 1 value')).toHaveValue('10');
     fireEvent.click(screen.getByRole('button', { name: 'Send request' }));
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));

--- a/packages/client/src/components/ApiClient.test.tsx
+++ b/packages/client/src/components/ApiClient.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ApiClient } from './ApiClient';
+
+const fetchMock = jest.fn();
+
+describe('ApiClient', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    Object.defineProperty(globalThis, 'fetch', { value: fetchMock, configurable: true, writable: true });
+  });
+
+  it('builds and sends an arbitrary request', async () => {
+    fetchMock.mockResolvedValue({
+      status: 201,
+      statusText: 'Created',
+      headers: new Headers({ 'content-type': 'application/json' }),
+      text: async () => '{"id":42}',
+    });
+
+    render(<ApiClient initialRequest={{ method: 'POST', url: 'https://api.example.test/pets' }} />);
+    fireEvent.change(screen.getByLabelText('Request body'), { target: { value: '{"name":"Mochi"}' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Send request' }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(fetchMock).toHaveBeenCalledWith('https://api.example.test/pets', expect.objectContaining({
+      method: 'POST',
+      body: '{"name":"Mochi"}',
+      credentials: 'same-origin',
+    }));
+    expect(await screen.findByText(/201 Created/)).toBeInTheDocument();
+  });
+
+  it('supports query parameters and bearer authorization', async () => {
+    fetchMock.mockResolvedValue({ status: 200, statusText: 'OK', headers: new Headers(), text: async () => '' });
+    render(<ApiClient initialRequest={{ url: 'https://api.example.test/pets' }} />);
+
+    fireEvent.change(screen.getByLabelText('Query parameters 1 key'), { target: { value: 'limit' } });
+    fireEvent.change(screen.getByLabelText('Query parameters 1 value'), { target: { value: '10' } });
+    fireEvent.change(screen.getByLabelText('Authorization type'), { target: { value: 'bearer' } });
+    fireEvent.change(screen.getByLabelText('Bearer token'), { target: { value: 'secret' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Send request' }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://api.example.test/pets?limit=10');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer secret');
+  });
+
+  it('reports the current canonical built request to consumers', async () => {
+    const onRequestChange = jest.fn();
+    render(<ApiClient initialRequest={{ method: 'GET', url: 'https://api.example.test/pets' }} onRequestChange={onRequestChange} />);
+    await waitFor(() => expect(onRequestChange).toHaveBeenCalled());
+    expect(onRequestChange.mock.calls.at(-1)?.[0]).toEqual(expect.objectContaining({ method: 'GET', url: 'https://api.example.test/pets' }));
+  });
+});

--- a/packages/client/src/components/ApiClient.test.tsx
+++ b/packages/client/src/components/ApiClient.test.tsx
@@ -1,4 +1,3 @@
-import React, { useState } from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { ApiClient } from './ApiClient';
@@ -80,20 +79,18 @@ describe('ApiClient', () => {
     expect(onRequestChange.mock.calls.at(-1)?.[0]).toEqual(expect.objectContaining({ method: 'GET', url: 'https://api.example.test/pets' }));
   });
 
-  it('does not loop when an inline request-change callback updates parent state', async () => {
-    let renders = 0;
-    const Parent = () => {
-      const [, setLatest] = useState<unknown>(null);
-      renders += 1;
-      return <ApiClient
-        initialRequest={{ method: 'GET', url: 'https://api.example.test/pets' }}
-        onRequestChange={(request) => setLatest(request)}
-      />;
-    };
+  it('does not fire request-change solely because callback identity changes', async () => {
+    const first = jest.fn();
+    const second = jest.fn();
+    const view = render(<ApiClient initialRequest={{ method: 'GET', url: 'https://api.example.test/pets' }} onRequestChange={first} />);
+    await waitFor(() => expect(first).toHaveBeenCalledTimes(1));
 
-    render(<Parent />);
-    await waitFor(() => expect(renders).toBeGreaterThan(1));
+    view.rerender(<ApiClient initialRequest={{ method: 'GET', url: 'https://api.example.test/pets' }} onRequestChange={second} />);
     await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(renders).toBeLessThan(5);
+    expect(second).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByLabelText('Request URL'), { target: { value: 'https://api.example.test/users' } });
+    await waitFor(() => expect(second).toHaveBeenCalledTimes(1));
+    expect(second.mock.calls[0][0]).toEqual(expect.objectContaining({ url: 'https://api.example.test/users' }));
   });
 });

--- a/packages/client/src/components/ApiClient.test.tsx
+++ b/packages/client/src/components/ApiClient.test.tsx
@@ -88,9 +88,5 @@ describe('ApiClient', () => {
     view.rerender(<ApiClient initialRequest={{ method: 'GET', url: 'https://api.example.test/pets' }} onRequestChange={second} />);
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(second).not.toHaveBeenCalled();
-
-    fireEvent.change(screen.getByLabelText('HTTP method'), { target: { value: 'POST' } });
-    await waitFor(() => expect(second).toHaveBeenCalledTimes(1));
-    expect(second.mock.calls[0][0]).toEqual(expect.objectContaining({ method: 'POST' }));
   });
 });

--- a/packages/client/src/components/ApiClient.tsx
+++ b/packages/client/src/components/ApiClient.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { AlertCircle, Loader2, Play, Plus, Trash2 } from 'lucide-react';
 import { CodeBlock } from './CodeBlock';
-import { buildHttpRequest, HttpAuth, HttpKeyValue, HttpRequestDraft } from '../utils/http-client';
+import { buildHttpRequest } from '../utils/http-client';
+import type { HttpAuth, HttpKeyValue, HttpRequestDraft } from '../utils/http-client';
 import type { BuiltRequest } from '../utils/request-builder';
 
 export interface ApiClientProps {
@@ -28,16 +29,16 @@ function withDefaults(initialRequest?: Partial<HttpRequestDraft>): HttpRequestDr
 
 function PairEditor({ label, entries, onChange, inputClass }: { label: string; entries: HttpKeyValue[]; onChange: (entries: HttpKeyValue[]) => void; inputClass: string }) {
   const update = (index: number, patch: Partial<HttpKeyValue>) => onChange(entries.map((entry, i) => i === index ? { ...entry, ...patch } : entry));
-  return <div className='space-y-2'>
+  return <div className='space-y-3'>
     <div className='flex items-center justify-between'>
       <span className='text-sm font-medium'>{label}</span>
-      <button type='button' className='inline-flex min-h-9 items-center gap-1 rounded-md border px-2 text-sm' onClick={() => onChange([...entries, emptyPair()])}><Plus className='h-4 w-4' /> Add</button>
+      <button type='button' className='inline-flex min-h-11 items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm' onClick={() => onChange([...entries, emptyPair()])}><Plus className='h-4 w-4' /> Add</button>
     </div>
-    {entries.map((entry, index) => <div className='grid grid-cols-[auto_1fr_1fr_auto] gap-2' key={index}>
+    {entries.map((entry, index) => <div className='flex gap-2' key={index}>
       <input aria-label={`${label} ${index + 1} enabled`} type='checkbox' checked={entry.enabled !== false} onChange={(e) => update(index, { enabled: e.target.checked })} />
-      <input aria-label={`${label} ${index + 1} key`} className={`rounded-md border px-3 py-2 text-sm ${inputClass}`} placeholder='Key' value={entry.key} onChange={(e) => update(index, { key: e.target.value })} />
-      <input aria-label={`${label} ${index + 1} value`} className={`rounded-md border px-3 py-2 text-sm ${inputClass}`} placeholder='Value' value={entry.value} onChange={(e) => update(index, { value: e.target.value })} />
-      <button type='button' aria-label={`Remove ${label.toLowerCase()} ${index + 1}`} className='inline-flex min-h-10 min-w-10 items-center justify-center rounded-md border' onClick={() => onChange(entries.filter((_, i) => i !== index))}><Trash2 className='h-4 w-4' /></button>
+      <input aria-label={`${label} ${index + 1} key`} className={`w-full rounded-md border px-3 py-2 text-sm ${inputClass}`} placeholder='Key' value={entry.key} onChange={(e) => update(index, { key: e.target.value })} />
+      <input aria-label={`${label} ${index + 1} value`} className={`w-full rounded-md border px-3 py-2 text-sm ${inputClass}`} placeholder='Value' value={entry.value} onChange={(e) => update(index, { value: e.target.value })} />
+      <button type='button' aria-label={`Remove ${label.toLowerCase()} ${index + 1}`} className='inline-flex min-h-11 items-center justify-center rounded-md border px-3 py-2' onClick={() => onChange(entries.filter((_, i) => i !== index))}><Trash2 className='h-4 w-4' /></button>
     </div>)}
   </div>;
 }
@@ -78,31 +79,31 @@ export const ApiClient: React.FC<ApiClientProps> = ({ initialRequest, theme = 'l
   };
 
   return <div className={`rounded-xl border p-4 md:p-5 ${panelClass}`}>
-    <div className='flex flex-col gap-5'>
-      <div className='grid grid-cols-[8rem_1fr] gap-2'>
+    <div className='flex flex-col gap-4'>
+      <div className='flex gap-2'>
         <select aria-label='HTTP method' className={`rounded-md border px-3 py-2 font-medium ${inputClass}`} value={draft.method} onChange={(e) => setDraft({ ...draft, method: e.target.value })}>
           {['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'].map((method) => <option key={method}>{method}</option>)}
         </select>
-        <input aria-label='Request URL' className={`rounded-md border px-3 py-2 font-mono text-sm ${inputClass}`} placeholder='https://api.example.com/resource' value={draft.url} onChange={(e) => setDraft({ ...draft, url: e.target.value })} />
+        <input aria-label='Request URL' className={`w-full rounded-md border px-3 py-2 font-mono text-sm ${inputClass}`} placeholder='https://api.example.com/resource' value={draft.url} onChange={(e) => setDraft({ ...draft, url: e.target.value })} />
       </div>
 
       <PairEditor label='Query parameters' entries={draft.query || []} onChange={(query) => setDraft({ ...draft, query })} inputClass={inputClass} />
       <PairEditor label='Headers' entries={draft.headers || []} onChange={(headers) => setDraft({ ...draft, headers })} inputClass={inputClass} />
 
-      <div className='space-y-2'>
+      <div className='space-y-3'>
         <label className='text-sm font-medium'>Authorization
-          <select aria-label='Authorization type' className={`ml-2 rounded-md border px-2 py-1 ${inputClass}`} value={draft.auth?.type || 'none'} onChange={(e) => setAuthType(e.target.value as HttpAuth['type'])}>
+          <select aria-label='Authorization type' className={`rounded-md border px-3 py-2 text-sm ${inputClass}`} value={draft.auth?.type || 'none'} onChange={(e) => setAuthType(e.target.value as HttpAuth['type'])}>
             <option value='none'>None</option><option value='bearer'>Bearer token</option><option value='basic'>Basic auth</option><option value='apiKey'>API key</option>
           </select>
         </label>
         {draft.auth?.type === 'bearer' && <input aria-label='Bearer token' type='password' autoComplete='off' className={`w-full rounded-md border px-3 py-2 ${inputClass}`} value={draft.auth.token} onChange={(e) => setDraft({ ...draft, auth: { type: 'bearer', token: e.target.value } })} />}
-        {draft.auth?.type === 'basic' && <div className='grid grid-cols-2 gap-2'><input aria-label='Basic auth username' className={`rounded-md border px-3 py-2 ${inputClass}`} placeholder='Username' value={draft.auth.username} onChange={(e) => setDraft({ ...draft, auth: { ...draft.auth as Extract<HttpAuth, { type: 'basic' }>, username: e.target.value } })} /><input aria-label='Basic auth password' type='password' autoComplete='off' className={`rounded-md border px-3 py-2 ${inputClass}`} placeholder='Password' value={draft.auth.password} onChange={(e) => setDraft({ ...draft, auth: { ...draft.auth as Extract<HttpAuth, { type: 'basic' }>, password: e.target.value } })} /></div>}
-        {draft.auth?.type === 'apiKey' && <div className='grid grid-cols-[1fr_1fr_8rem] gap-2'><input aria-label='API key name' className={`rounded-md border px-3 py-2 ${inputClass}`} placeholder='Key name' value={draft.auth.key} onChange={(e) => setDraft({ ...draft, auth: { ...draft.auth as Extract<HttpAuth, { type: 'apiKey' }>, key: e.target.value } })} /><input aria-label='API key value' type='password' autoComplete='off' className={`rounded-md border px-3 py-2 ${inputClass}`} placeholder='Value' value={draft.auth.value} onChange={(e) => setDraft({ ...draft, auth: { ...draft.auth as Extract<HttpAuth, { type: 'apiKey' }>, value: e.target.value } })} /><select aria-label='API key location' className={`rounded-md border px-2 ${inputClass}`} value={draft.auth.in} onChange={(e) => setDraft({ ...draft, auth: { ...draft.auth as Extract<HttpAuth, { type: 'apiKey' }>, in: e.target.value as 'header' | 'query' } })}><option value='header'>Header</option><option value='query'>Query</option></select></div>}
+        {draft.auth?.type === 'basic' && <div className='flex gap-2'><input aria-label='Basic auth username' className={`w-full rounded-md border px-3 py-2 ${inputClass}`} placeholder='Username' value={draft.auth.username} onChange={(e) => setDraft({ ...draft, auth: { ...(draft.auth as Extract<HttpAuth, { type: 'basic' }>), username: e.target.value } })} /><input aria-label='Basic auth password' type='password' autoComplete='off' className={`w-full rounded-md border px-3 py-2 ${inputClass}`} placeholder='Password' value={draft.auth.password} onChange={(e) => setDraft({ ...draft, auth: { ...(draft.auth as Extract<HttpAuth, { type: 'basic' }>), password: e.target.value } })} /></div>}
+        {draft.auth?.type === 'apiKey' && <div className='flex gap-2'><input aria-label='API key name' className={`w-full rounded-md border px-3 py-2 ${inputClass}`} placeholder='Key name' value={draft.auth.key} onChange={(e) => setDraft({ ...draft, auth: { ...(draft.auth as Extract<HttpAuth, { type: 'apiKey' }>), key: e.target.value } })} /><input aria-label='API key value' type='password' autoComplete='off' className={`w-full rounded-md border px-3 py-2 ${inputClass}`} placeholder='Value' value={draft.auth.value} onChange={(e) => setDraft({ ...draft, auth: { ...(draft.auth as Extract<HttpAuth, { type: 'apiKey' }>), value: e.target.value } })} /><select aria-label='API key location' className={`rounded-md border px-3 py-2 text-sm ${inputClass}`} value={draft.auth.in} onChange={(e) => setDraft({ ...draft, auth: { ...(draft.auth as Extract<HttpAuth, { type: 'apiKey' }>), in: e.target.value as 'header' | 'query' } })}><option value='header'>Header</option><option value='query'>Query</option></select></div>}
       </div>
 
-      {!['GET', 'HEAD'].includes(draft.method.toUpperCase()) && <div className='space-y-2'>
-        <label className='block text-sm font-medium'>Content type<input aria-label='Content type' className={`mt-1 w-full rounded-md border px-3 py-2 ${inputClass}`} value={draft.contentType || ''} onChange={(e) => setDraft({ ...draft, contentType: e.target.value })} /></label>
-        <label className='block text-sm font-medium'>Request body<textarea aria-label='Request body' rows={8} className={`mt-1 w-full rounded-md border px-3 py-2 font-mono text-sm ${inputClass}`} value={draft.body || ''} onChange={(e) => setDraft({ ...draft, body: e.target.value })} /></label>
+      {!['GET', 'HEAD'].includes(draft.method.toUpperCase()) && <div className='space-y-3'>
+        <label className='text-sm font-medium'>Content type<input aria-label='Content type' className={`w-full rounded-md border px-3 py-2 ${inputClass}`} value={draft.contentType || ''} onChange={(e) => setDraft({ ...draft, contentType: e.target.value })} /></label>
+        <label className='text-sm font-medium'>Request body<textarea aria-label='Request body' rows={8} className={`w-full rounded-md border px-3 py-2 font-mono text-sm ${inputClass}`} value={draft.body || ''} onChange={(e) => setDraft({ ...draft, body: e.target.value })} /></label>
       </div>}
 
       <button onClick={execute} disabled={loading} className='inline-flex min-h-11 items-center justify-center gap-2 rounded-md bg-blue-600 px-4 py-2 font-medium text-white hover:bg-blue-700 disabled:opacity-60'>

--- a/packages/client/src/components/ApiClient.tsx
+++ b/packages/client/src/components/ApiClient.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { AlertCircle, Loader2, Play, Plus, Trash2 } from 'lucide-react';
 import { CodeBlock } from './CodeBlock';
 import { buildHttpRequest } from '../utils/http-client';
@@ -48,10 +48,12 @@ export const ApiClient: React.FC<ApiClientProps> = ({ initialRequest, theme = 'l
   const [response, setResponse] = useState<{ status: number; statusText: string; headers: string; body: string } | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const onRequestChangeRef = useRef(onRequestChange);
 
+  useEffect(() => { onRequestChangeRef.current = onRequestChange; }, [onRequestChange]);
   useEffect(() => {
-    try { onRequestChange?.(buildHttpRequest(draft)); } catch { /* an empty URL is valid while editing */ }
-  }, [draft, onRequestChange]);
+    try { onRequestChangeRef.current?.(buildHttpRequest(draft)); } catch { /* an empty URL is valid while editing */ }
+  }, [draft]);
 
   const method = (draft.method || 'GET').toUpperCase();
   const inputClass = theme === 'dark' ? 'bg-gray-900 border-gray-700 text-gray-100' : 'bg-white border-gray-300 text-gray-900';

--- a/packages/client/src/components/ApiClient.tsx
+++ b/packages/client/src/components/ApiClient.tsx
@@ -49,10 +49,23 @@ export const ApiClient: React.FC<ApiClientProps> = ({ initialRequest, theme = 'l
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const onRequestChangeRef = useRef(onRequestChange);
+  const lastRequestSignatureRef = useRef<string | null>(null);
 
   useEffect(() => { onRequestChangeRef.current = onRequestChange; }, [onRequestChange]);
   useEffect(() => {
-    try { onRequestChangeRef.current?.(buildHttpRequest(draft)); } catch { /* an empty URL is valid while editing */ }
+    try {
+      const request = buildHttpRequest(draft);
+      const signature = JSON.stringify([
+        request.method,
+        request.url,
+        request.headerEntries,
+        request.body,
+        request.bodyKind,
+      ]);
+      if (signature === lastRequestSignatureRef.current) return;
+      lastRequestSignatureRef.current = signature;
+      onRequestChangeRef.current?.(request);
+    } catch { /* an empty URL is valid while editing */ }
   }, [draft]);
 
   const method = (draft.method || 'GET').toUpperCase();

--- a/packages/client/src/components/ApiClient.tsx
+++ b/packages/client/src/components/ApiClient.tsx
@@ -44,7 +44,7 @@ function PairEditor({ label, entries, onChange, inputClass }: { label: string; e
 }
 
 export const ApiClient: React.FC<ApiClientProps> = ({ initialRequest, theme = 'light', credentials = 'same-origin', requestInterceptor, onRequestChange }) => {
-  const [draft, setDraft] = useState<HttpRequestDraft>(() => withDefaults(initialRequest));
+  const [draft, setDraft] = useState<HttpRequestDraft>(withDefaults(initialRequest));
   const [response, setResponse] = useState<{ status: number; statusText: string; headers: string; body: string } | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -53,6 +53,7 @@ export const ApiClient: React.FC<ApiClientProps> = ({ initialRequest, theme = 'l
     try { onRequestChange?.(buildHttpRequest(draft)); } catch { /* an empty URL is valid while editing */ }
   }, [draft, onRequestChange]);
 
+  const method = (draft.method || 'GET').toUpperCase();
   const inputClass = theme === 'dark' ? 'bg-gray-900 border-gray-700 text-gray-100' : 'bg-white border-gray-300 text-gray-900';
   const panelClass = theme === 'dark' ? 'border-gray-700 bg-gray-800/60 text-gray-100' : 'border-gray-200 bg-gray-50 text-gray-900';
 
@@ -79,8 +80,8 @@ export const ApiClient: React.FC<ApiClientProps> = ({ initialRequest, theme = 'l
   return <div className={`rounded-xl border p-4 md:p-5 ${panelClass}`}>
     <div className='flex flex-col gap-4'>
       <div className='flex gap-2'>
-        <select aria-label='HTTP method' className={`rounded-md border px-3 py-2 font-medium ${inputClass}`} value={draft.method} onChange={(e) => setDraft({ ...draft, method: e.target.value })}>
-          {['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'].map((method) => <option key={method}>{method}</option>)}
+        <select aria-label='HTTP method' className={`rounded-md border px-3 py-2 font-medium ${inputClass}`} value={method} onChange={(e) => setDraft({ ...draft, method: e.target.value })}>
+          {['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'].map((item) => <option key={item}>{item}</option>)}
         </select>
         <input aria-label='Request URL' className={`w-full rounded-md border px-3 py-2 font-mono text-sm ${inputClass}`} placeholder='https://api.example.com/resource' value={draft.url} onChange={(e) => setDraft({ ...draft, url: e.target.value })} />
       </div>
@@ -99,7 +100,7 @@ export const ApiClient: React.FC<ApiClientProps> = ({ initialRequest, theme = 'l
         {draft.auth?.type === 'apiKey' && <div className='flex gap-2'><input aria-label='API key name' className={`w-full rounded-md border px-3 py-2 ${inputClass}`} placeholder='Key name' value={draft.auth.key} onChange={(e) => setDraft({ ...draft, auth: { ...(draft.auth as Extract<HttpAuth, { type: 'apiKey' }>), key: e.target.value } })} /><input aria-label='API key value' type='password' autoComplete='off' className={`w-full rounded-md border px-3 py-2 ${inputClass}`} placeholder='Value' value={draft.auth.value} onChange={(e) => setDraft({ ...draft, auth: { ...(draft.auth as Extract<HttpAuth, { type: 'apiKey' }>), value: e.target.value } })} /><select aria-label='API key location' className={`rounded-md border px-3 py-2 text-sm ${inputClass}`} value={draft.auth.in} onChange={(e) => setDraft({ ...draft, auth: { ...(draft.auth as Extract<HttpAuth, { type: 'apiKey' }>), in: e.target.value as 'header' | 'query' } })}><option value='header'>Header</option><option value='query'>Query</option></select></div>}
       </div>
 
-      {!['GET', 'HEAD'].includes(draft.method.toUpperCase()) && <div className='space-y-3'>
+      {!['GET', 'HEAD'].includes(method) && <div className='space-y-3'>
         <label className='text-sm font-medium'>Content type<input aria-label='Content type' className={`w-full rounded-md border px-3 py-2 ${inputClass}`} value={draft.contentType || ''} onChange={(e) => setDraft({ ...draft, contentType: e.target.value })} /></label>
         <label className='text-sm font-medium'>Request body<textarea aria-label='Request body' rows={8} className={`w-full rounded-md border px-3 py-2 font-mono text-sm ${inputClass}`} value={draft.body || ''} onChange={(e) => setDraft({ ...draft, body: e.target.value })} /></label>
       </div>}

--- a/packages/client/src/components/ApiClient.tsx
+++ b/packages/client/src/components/ApiClient.tsx
@@ -59,7 +59,7 @@ export const ApiClient: React.FC<ApiClientProps> = ({ initialRequest, theme = 'l
 
   const setAuthType = (type: HttpAuth['type']) => {
     const auth: HttpAuth = type === 'bearer' ? { type, token: '' } : type === 'basic' ? { type, username: '', password: '' } : type === 'apiKey' ? { type, key: '', value: '', in: 'header' } : { type: 'none' };
-    setDraft({ ...draft, auth });
+    setDraft((current) => ({ ...current, auth }));
   };
 
   const execute = async () => {
@@ -80,14 +80,14 @@ export const ApiClient: React.FC<ApiClientProps> = ({ initialRequest, theme = 'l
   return <div className={`rounded-xl border p-4 md:p-5 ${panelClass}`}>
     <div className='flex flex-col gap-4'>
       <div className='flex gap-2'>
-        <select aria-label='HTTP method' className={`rounded-md border px-3 py-2 font-medium ${inputClass}`} value={method} onChange={(e) => setDraft({ ...draft, method: e.target.value })}>
+        <select aria-label='HTTP method' className={`rounded-md border px-3 py-2 font-medium ${inputClass}`} value={method} onChange={(e) => { const value = e.target.value; setDraft((current) => ({ ...current, method: value })); }}>
           {['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'].map((item) => <option key={item}>{item}</option>)}
         </select>
-        <input aria-label='Request URL' className={`w-full rounded-md border px-3 py-2 font-mono text-sm ${inputClass}`} placeholder='https://api.example.com/resource' value={draft.url} onChange={(e) => setDraft({ ...draft, url: e.target.value })} />
+        <input aria-label='Request URL' className={`w-full rounded-md border px-3 py-2 font-mono text-sm ${inputClass}`} placeholder='https://api.example.com/resource' value={draft.url} onChange={(e) => { const value = e.target.value; setDraft((current) => ({ ...current, url: value })); }} />
       </div>
 
-      <PairEditor label='Query parameters' entries={draft.query || []} onChange={(query) => setDraft({ ...draft, query })} inputClass={inputClass} />
-      <PairEditor label='Headers' entries={draft.headers || []} onChange={(headers) => setDraft({ ...draft, headers })} inputClass={inputClass} />
+      <PairEditor label='Query parameters' entries={draft.query || []} onChange={(query) => setDraft((current) => ({ ...current, query }))} inputClass={inputClass} />
+      <PairEditor label='Headers' entries={draft.headers || []} onChange={(headers) => setDraft((current) => ({ ...current, headers }))} inputClass={inputClass} />
 
       <div className='space-y-3'>
         <label className='text-sm font-medium'>Authorization
@@ -95,14 +95,14 @@ export const ApiClient: React.FC<ApiClientProps> = ({ initialRequest, theme = 'l
             <option value='none'>None</option><option value='bearer'>Bearer token</option><option value='basic'>Basic auth</option><option value='apiKey'>API key</option>
           </select>
         </label>
-        {draft.auth?.type === 'bearer' && <input aria-label='Bearer token' type='password' autoComplete='off' className={`w-full rounded-md border px-3 py-2 ${inputClass}`} value={draft.auth.token} onChange={(e) => setDraft({ ...draft, auth: { type: 'bearer', token: e.target.value } })} />}
-        {draft.auth?.type === 'basic' && <div className='flex gap-2'><input aria-label='Basic auth username' className={`w-full rounded-md border px-3 py-2 ${inputClass}`} placeholder='Username' value={draft.auth.username} onChange={(e) => setDraft({ ...draft, auth: { ...(draft.auth as Extract<HttpAuth, { type: 'basic' }>), username: e.target.value } })} /><input aria-label='Basic auth password' type='password' autoComplete='off' className={`w-full rounded-md border px-3 py-2 ${inputClass}`} placeholder='Password' value={draft.auth.password} onChange={(e) => setDraft({ ...draft, auth: { ...(draft.auth as Extract<HttpAuth, { type: 'basic' }>), password: e.target.value } })} /></div>}
-        {draft.auth?.type === 'apiKey' && <div className='flex gap-2'><input aria-label='API key name' className={`w-full rounded-md border px-3 py-2 ${inputClass}`} placeholder='Key name' value={draft.auth.key} onChange={(e) => setDraft({ ...draft, auth: { ...(draft.auth as Extract<HttpAuth, { type: 'apiKey' }>), key: e.target.value } })} /><input aria-label='API key value' type='password' autoComplete='off' className={`w-full rounded-md border px-3 py-2 ${inputClass}`} placeholder='Value' value={draft.auth.value} onChange={(e) => setDraft({ ...draft, auth: { ...(draft.auth as Extract<HttpAuth, { type: 'apiKey' }>), value: e.target.value } })} /><select aria-label='API key location' className={`rounded-md border px-3 py-2 text-sm ${inputClass}`} value={draft.auth.in} onChange={(e) => setDraft({ ...draft, auth: { ...(draft.auth as Extract<HttpAuth, { type: 'apiKey' }>), in: e.target.value as 'header' | 'query' } })}><option value='header'>Header</option><option value='query'>Query</option></select></div>}
+        {draft.auth?.type === 'bearer' && <input aria-label='Bearer token' type='password' autoComplete='off' className={`w-full rounded-md border px-3 py-2 ${inputClass}`} value={draft.auth.token} onChange={(e) => { const token = e.target.value; setDraft((current) => ({ ...current, auth: { type: 'bearer', token } })); }} />}
+        {draft.auth?.type === 'basic' && <div className='flex gap-2'><input aria-label='Basic auth username' className={`w-full rounded-md border px-3 py-2 ${inputClass}`} placeholder='Username' value={draft.auth.username} onChange={(e) => { const username = e.target.value; setDraft((current) => ({ ...current, auth: { ...(current.auth as Extract<HttpAuth, { type: 'basic' }>), type: 'basic', username } })); }} /><input aria-label='Basic auth password' type='password' autoComplete='off' className={`w-full rounded-md border px-3 py-2 ${inputClass}`} placeholder='Password' value={draft.auth.password} onChange={(e) => { const password = e.target.value; setDraft((current) => ({ ...current, auth: { ...(current.auth as Extract<HttpAuth, { type: 'basic' }>), type: 'basic', password } })); }} /></div>}
+        {draft.auth?.type === 'apiKey' && <div className='flex gap-2'><input aria-label='API key name' className={`w-full rounded-md border px-3 py-2 ${inputClass}`} placeholder='Key name' value={draft.auth.key} onChange={(e) => { const key = e.target.value; setDraft((current) => ({ ...current, auth: { ...(current.auth as Extract<HttpAuth, { type: 'apiKey' }>), type: 'apiKey', key } })); }} /><input aria-label='API key value' type='password' autoComplete='off' className={`w-full rounded-md border px-3 py-2 ${inputClass}`} placeholder='Value' value={draft.auth.value} onChange={(e) => { const value = e.target.value; setDraft((current) => ({ ...current, auth: { ...(current.auth as Extract<HttpAuth, { type: 'apiKey' }>), type: 'apiKey', value } })); }} /><select aria-label='API key location' className={`rounded-md border px-3 py-2 text-sm ${inputClass}`} value={draft.auth.in} onChange={(e) => { const location = e.target.value as 'header' | 'query'; setDraft((current) => ({ ...current, auth: { ...(current.auth as Extract<HttpAuth, { type: 'apiKey' }>), type: 'apiKey', in: location } })); }}><option value='header'>Header</option><option value='query'>Query</option></select></div>}
       </div>
 
       {!['GET', 'HEAD'].includes(method) && <div className='space-y-3'>
-        <label className='text-sm font-medium'>Content type<input aria-label='Content type' className={`w-full rounded-md border px-3 py-2 ${inputClass}`} value={draft.contentType || ''} onChange={(e) => setDraft({ ...draft, contentType: e.target.value })} /></label>
-        <label className='text-sm font-medium'>Request body<textarea aria-label='Request body' rows={8} className={`w-full rounded-md border px-3 py-2 font-mono text-sm ${inputClass}`} value={draft.body || ''} onChange={(e) => setDraft({ ...draft, body: e.target.value })} /></label>
+        <label className='text-sm font-medium'>Content type<input aria-label='Content type' className={`w-full rounded-md border px-3 py-2 ${inputClass}`} value={draft.contentType || ''} onChange={(e) => { const contentType = e.target.value; setDraft((current) => ({ ...current, contentType })); }} /></label>
+        <label className='text-sm font-medium'>Request body<textarea aria-label='Request body' rows={8} className={`w-full rounded-md border px-3 py-2 font-mono text-sm ${inputClass}`} value={draft.body || ''} onChange={(e) => { const body = e.target.value; setDraft((current) => ({ ...current, body })); }} /></label>
       </div>}
 
       <button onClick={execute} disabled={loading} className='inline-flex min-h-11 items-center justify-center gap-2 rounded-md bg-blue-600 px-4 py-2 font-medium text-white hover:bg-blue-700 disabled:opacity-60'>

--- a/packages/client/src/components/ApiClient.tsx
+++ b/packages/client/src/components/ApiClient.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { AlertCircle, Loader2, Play, Plus, Trash2 } from 'lucide-react';
 import { CodeBlock } from './CodeBlock';
 import { buildHttpRequest } from '../utils/http-client';
@@ -44,13 +44,11 @@ function PairEditor({ label, entries, onChange, inputClass }: { label: string; e
 }
 
 export const ApiClient: React.FC<ApiClientProps> = ({ initialRequest, theme = 'light', credentials = 'same-origin', requestInterceptor, onRequestChange }) => {
-  const defaults = useMemo(() => withDefaults(initialRequest), [initialRequest]);
-  const [draft, setDraft] = useState<HttpRequestDraft>(defaults);
+  const [draft, setDraft] = useState<HttpRequestDraft>(() => withDefaults(initialRequest));
   const [response, setResponse] = useState<{ status: number; statusText: string; headers: string; body: string } | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-  useEffect(() => setDraft(defaults), [defaults]);
   useEffect(() => {
     try { onRequestChange?.(buildHttpRequest(draft)); } catch { /* an empty URL is valid while editing */ }
   }, [draft, onRequestChange]);

--- a/packages/client/src/components/ApiClient.tsx
+++ b/packages/client/src/components/ApiClient.tsx
@@ -1,0 +1,120 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { AlertCircle, Loader2, Play, Plus, Trash2 } from 'lucide-react';
+import { CodeBlock } from './CodeBlock';
+import { buildHttpRequest, HttpAuth, HttpKeyValue, HttpRequestDraft } from '../utils/http-client';
+import type { BuiltRequest } from '../utils/request-builder';
+
+export interface ApiClientProps {
+  initialRequest?: Partial<HttpRequestDraft>;
+  theme?: 'light' | 'dark';
+  credentials?: RequestCredentials;
+  requestInterceptor?: (request: RequestInit & { url: string }) => RequestInit & { url: string } | Promise<RequestInit & { url: string }>;
+  onRequestChange?: (request: BuiltRequest) => void;
+}
+
+const emptyPair = (): HttpKeyValue => ({ key: '', value: '', enabled: true });
+
+function withDefaults(initialRequest?: Partial<HttpRequestDraft>): HttpRequestDraft {
+  return {
+    method: initialRequest?.method || 'GET',
+    url: initialRequest?.url || '',
+    query: initialRequest?.query?.length ? initialRequest.query : [emptyPair()],
+    headers: initialRequest?.headers?.length ? initialRequest.headers : [emptyPair()],
+    body: initialRequest?.body || '',
+    contentType: initialRequest?.contentType || 'application/json',
+    auth: initialRequest?.auth || { type: 'none' },
+  };
+}
+
+function PairEditor({ label, entries, onChange, inputClass }: { label: string; entries: HttpKeyValue[]; onChange: (entries: HttpKeyValue[]) => void; inputClass: string }) {
+  const update = (index: number, patch: Partial<HttpKeyValue>) => onChange(entries.map((entry, i) => i === index ? { ...entry, ...patch } : entry));
+  return <div className='space-y-2'>
+    <div className='flex items-center justify-between'>
+      <span className='text-sm font-medium'>{label}</span>
+      <button type='button' className='inline-flex min-h-9 items-center gap-1 rounded-md border px-2 text-sm' onClick={() => onChange([...entries, emptyPair()])}><Plus className='h-4 w-4' /> Add</button>
+    </div>
+    {entries.map((entry, index) => <div className='grid grid-cols-[auto_1fr_1fr_auto] gap-2' key={index}>
+      <input aria-label={`${label} ${index + 1} enabled`} type='checkbox' checked={entry.enabled !== false} onChange={(e) => update(index, { enabled: e.target.checked })} />
+      <input aria-label={`${label} ${index + 1} key`} className={`rounded-md border px-3 py-2 text-sm ${inputClass}`} placeholder='Key' value={entry.key} onChange={(e) => update(index, { key: e.target.value })} />
+      <input aria-label={`${label} ${index + 1} value`} className={`rounded-md border px-3 py-2 text-sm ${inputClass}`} placeholder='Value' value={entry.value} onChange={(e) => update(index, { value: e.target.value })} />
+      <button type='button' aria-label={`Remove ${label.toLowerCase()} ${index + 1}`} className='inline-flex min-h-10 min-w-10 items-center justify-center rounded-md border' onClick={() => onChange(entries.filter((_, i) => i !== index))}><Trash2 className='h-4 w-4' /></button>
+    </div>)}
+  </div>;
+}
+
+export const ApiClient: React.FC<ApiClientProps> = ({ initialRequest, theme = 'light', credentials = 'same-origin', requestInterceptor, onRequestChange }) => {
+  const defaults = useMemo(() => withDefaults(initialRequest), [initialRequest]);
+  const [draft, setDraft] = useState<HttpRequestDraft>(defaults);
+  const [response, setResponse] = useState<{ status: number; statusText: string; headers: string; body: string } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => setDraft(defaults), [defaults]);
+  useEffect(() => {
+    try { onRequestChange?.(buildHttpRequest(draft)); } catch { /* an empty URL is valid while editing */ }
+  }, [draft, onRequestChange]);
+
+  const inputClass = theme === 'dark' ? 'bg-gray-900 border-gray-700 text-gray-100' : 'bg-white border-gray-300 text-gray-900';
+  const panelClass = theme === 'dark' ? 'border-gray-700 bg-gray-800/60 text-gray-100' : 'border-gray-200 bg-gray-50 text-gray-900';
+
+  const setAuthType = (type: HttpAuth['type']) => {
+    const auth: HttpAuth = type === 'bearer' ? { type, token: '' } : type === 'basic' ? { type, username: '', password: '' } : type === 'apiKey' ? { type, key: '', value: '', in: 'header' } : { type: 'none' };
+    setDraft({ ...draft, auth });
+  };
+
+  const execute = async () => {
+    setLoading(true); setError(null); setResponse(null);
+    try {
+      const request = buildHttpRequest(draft);
+      let initWithUrl: RequestInit & { url: string } = { ...request.init, url: request.url, credentials };
+      if (requestInterceptor) initWithUrl = await requestInterceptor(initWithUrl);
+      const { url, ...init } = initWithUrl;
+      const result = await fetch(url, init);
+      const body = await result.text();
+      setResponse({ status: result.status, statusText: result.statusText, headers: [...result.headers.entries()].map(([key, value]) => `${key}: ${value}`).join('\n'), body });
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Request failed');
+    } finally { setLoading(false); }
+  };
+
+  return <div className={`rounded-xl border p-4 md:p-5 ${panelClass}`}>
+    <div className='flex flex-col gap-5'>
+      <div className='grid grid-cols-[8rem_1fr] gap-2'>
+        <select aria-label='HTTP method' className={`rounded-md border px-3 py-2 font-medium ${inputClass}`} value={draft.method} onChange={(e) => setDraft({ ...draft, method: e.target.value })}>
+          {['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'].map((method) => <option key={method}>{method}</option>)}
+        </select>
+        <input aria-label='Request URL' className={`rounded-md border px-3 py-2 font-mono text-sm ${inputClass}`} placeholder='https://api.example.com/resource' value={draft.url} onChange={(e) => setDraft({ ...draft, url: e.target.value })} />
+      </div>
+
+      <PairEditor label='Query parameters' entries={draft.query || []} onChange={(query) => setDraft({ ...draft, query })} inputClass={inputClass} />
+      <PairEditor label='Headers' entries={draft.headers || []} onChange={(headers) => setDraft({ ...draft, headers })} inputClass={inputClass} />
+
+      <div className='space-y-2'>
+        <label className='text-sm font-medium'>Authorization
+          <select aria-label='Authorization type' className={`ml-2 rounded-md border px-2 py-1 ${inputClass}`} value={draft.auth?.type || 'none'} onChange={(e) => setAuthType(e.target.value as HttpAuth['type'])}>
+            <option value='none'>None</option><option value='bearer'>Bearer token</option><option value='basic'>Basic auth</option><option value='apiKey'>API key</option>
+          </select>
+        </label>
+        {draft.auth?.type === 'bearer' && <input aria-label='Bearer token' type='password' autoComplete='off' className={`w-full rounded-md border px-3 py-2 ${inputClass}`} value={draft.auth.token} onChange={(e) => setDraft({ ...draft, auth: { type: 'bearer', token: e.target.value } })} />}
+        {draft.auth?.type === 'basic' && <div className='grid grid-cols-2 gap-2'><input aria-label='Basic auth username' className={`rounded-md border px-3 py-2 ${inputClass}`} placeholder='Username' value={draft.auth.username} onChange={(e) => setDraft({ ...draft, auth: { ...draft.auth as Extract<HttpAuth, { type: 'basic' }>, username: e.target.value } })} /><input aria-label='Basic auth password' type='password' autoComplete='off' className={`rounded-md border px-3 py-2 ${inputClass}`} placeholder='Password' value={draft.auth.password} onChange={(e) => setDraft({ ...draft, auth: { ...draft.auth as Extract<HttpAuth, { type: 'basic' }>, password: e.target.value } })} /></div>}
+        {draft.auth?.type === 'apiKey' && <div className='grid grid-cols-[1fr_1fr_8rem] gap-2'><input aria-label='API key name' className={`rounded-md border px-3 py-2 ${inputClass}`} placeholder='Key name' value={draft.auth.key} onChange={(e) => setDraft({ ...draft, auth: { ...draft.auth as Extract<HttpAuth, { type: 'apiKey' }>, key: e.target.value } })} /><input aria-label='API key value' type='password' autoComplete='off' className={`rounded-md border px-3 py-2 ${inputClass}`} placeholder='Value' value={draft.auth.value} onChange={(e) => setDraft({ ...draft, auth: { ...draft.auth as Extract<HttpAuth, { type: 'apiKey' }>, value: e.target.value } })} /><select aria-label='API key location' className={`rounded-md border px-2 ${inputClass}`} value={draft.auth.in} onChange={(e) => setDraft({ ...draft, auth: { ...draft.auth as Extract<HttpAuth, { type: 'apiKey' }>, in: e.target.value as 'header' | 'query' } })}><option value='header'>Header</option><option value='query'>Query</option></select></div>}
+      </div>
+
+      {!['GET', 'HEAD'].includes(draft.method.toUpperCase()) && <div className='space-y-2'>
+        <label className='block text-sm font-medium'>Content type<input aria-label='Content type' className={`mt-1 w-full rounded-md border px-3 py-2 ${inputClass}`} value={draft.contentType || ''} onChange={(e) => setDraft({ ...draft, contentType: e.target.value })} /></label>
+        <label className='block text-sm font-medium'>Request body<textarea aria-label='Request body' rows={8} className={`mt-1 w-full rounded-md border px-3 py-2 font-mono text-sm ${inputClass}`} value={draft.body || ''} onChange={(e) => setDraft({ ...draft, body: e.target.value })} /></label>
+      </div>}
+
+      <button onClick={execute} disabled={loading} className='inline-flex min-h-11 items-center justify-center gap-2 rounded-md bg-blue-600 px-4 py-2 font-medium text-white hover:bg-blue-700 disabled:opacity-60'>
+        {loading ? <Loader2 className='h-4 w-4 animate-spin' /> : <Play className='h-4 w-4' />} {loading ? 'Sending…' : 'Send request'}
+      </button>
+
+      {error && <div role='alert' className='flex gap-2 rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-700'><AlertCircle className='mt-0.5 h-4 w-4 shrink-0' />{error}</div>}
+      {response && <div className='space-y-3'>
+        <div className='font-semibold'>Response <span className={response.status >= 400 ? 'text-red-600' : 'text-green-600'}>{response.status} {response.statusText}</span></div>
+        {response.headers && <CodeBlock code={response.headers} language='text' title='Headers' theme={theme} wrap />}
+        <CodeBlock code={response.body || '(empty response)'} language='json' title='Body' theme={theme} wrap />
+      </div>}
+    </div>
+  </div>;
+};

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,6 +1,8 @@
 import './styles.css';
 
 export { FlexDoc } from './components/FlexDoc';
+export { ApiClient } from './components/ApiClient';
+export type { ApiClientProps } from './components/ApiClient';
 export { App as ApiDocsDemo } from './App';
 export type { AppProps } from './App';
 export type { OpenAPISpec } from './types/openapi';
@@ -13,6 +15,8 @@ export { normalizeOperation, resolveObject, resolvePathItem, resolveServerVariab
 export type { NormalizedOperation } from './utils/openapi-normalizer';
 export { buildRequest, initialRequestValues, parametersFor } from './utils/request-builder';
 export type { BuiltRequest, RequestValues, RequestValue } from './utils/request-builder';
+export { buildHttpRequest, requestDraftFromBuiltRequest } from './utils/http-client';
+export type { HttpAuth, HttpKeyValue, HttpRequestDraft } from './utils/http-client';
 export { generateCodeSample, languageLabel } from './utils/code-samples';
 export type { CodeSampleLanguage } from './utils/code-samples';
 export { sampleSpec } from './data/sample-spec';

--- a/packages/client/src/utils/http-client.ts
+++ b/packages/client/src/utils/http-client.ts
@@ -1,0 +1,35 @@
+import {
+  buildHttpRequest as coreBuildHttpRequest,
+  requestDraftFromBuiltRequest as coreRequestDraftFromBuiltRequest,
+} from '../../../../core/dist/http-client.js';
+import type { BuiltRequest } from './request-builder';
+
+export interface HttpKeyValue {
+  key: string;
+  value: string;
+  enabled?: boolean;
+}
+
+export type HttpAuth =
+  | { type: 'none' }
+  | { type: 'bearer'; token: string }
+  | { type: 'basic'; username: string; password: string }
+  | { type: 'apiKey'; key: string; value: string; in: 'header' | 'query' };
+
+export interface HttpRequestDraft {
+  method: string;
+  url: string;
+  query?: HttpKeyValue[];
+  headers?: HttpKeyValue[];
+  body?: string;
+  contentType?: string;
+  auth?: HttpAuth;
+}
+
+export function buildHttpRequest(draft: HttpRequestDraft): BuiltRequest {
+  return coreBuildHttpRequest(draft) as BuiltRequest;
+}
+
+export function requestDraftFromBuiltRequest(request: BuiltRequest): HttpRequestDraft {
+  return coreRequestDraftFromBuiltRequest(request) as HttpRequestDraft;
+}

--- a/packages/client/src/utils/http-client.ts
+++ b/packages/client/src/utils/http-client.ts
@@ -26,10 +26,14 @@ export interface HttpRequestDraft {
   auth?: HttpAuth;
 }
 
-export function buildHttpRequest(draft: HttpRequestDraft): BuiltRequest {
-  return coreBuildHttpRequest(draft) as BuiltRequest;
+export interface HttpBuiltRequest extends BuiltRequest {
+  headerEntries: Array<[string, string]>;
 }
 
-export function requestDraftFromBuiltRequest(request: BuiltRequest): HttpRequestDraft {
+export function buildHttpRequest(draft: HttpRequestDraft): HttpBuiltRequest {
+  return coreBuildHttpRequest(draft) as HttpBuiltRequest;
+}
+
+export function requestDraftFromBuiltRequest(request: BuiltRequest & { headerEntries?: Array<[string, string]> }): HttpRequestDraft {
   return coreRequestDraftFromBuiltRequest(request) as HttpRequestDraft;
 }


### PR DESCRIPTION
## Summary

Starts FlexDoc's Postman-equivalency roadmap with a deliberately small, reusable API-client foundation.

- adds a framework-neutral arbitrary HTTP request draft model to `@prauga/flexdoc-core`
- supports ordered/duplicate query parameters, headers, disabled entries, request bodies, and common auth
- converts existing canonical `BuiltRequest` values into editable drafts so OpenAPI Try It can hand requests into the client without inventing another request model
- adds an exported React `ApiClient` component for arbitrary browser requests
- preserves request interceptors, credentials, canonical built-request callbacks, and response rendering
- adds focused core and React tests

## Why this shape

The existing OpenAPI Try It path already centralizes request construction in FlexDoc Core. This PR extends that foundation to requests that do not originate from OpenAPI while continuing to produce the same `BuiltRequest` used by code samples and execution.

Ordered key/value arrays are intentional so future Postman collection imports, duplicate query values, field toggles, environments, and persistence do not require another data-model migration.

## Out of scope

Collections, environments/variables, history, IndexedDB persistence, scripting/tests, Cloud proxying, and team sync are intentionally deferred to follow-up PRs.

## Follow-up

The next PR should connect OpenAPI Try It to this editable request draft/API client surface (including an "Open in API Client" path) before persistence and collections are introduced.