### PR TITLE
Fix Elixir release version check

### DIFF
--- a/.github/workflows/publish-elixir.yml
+++ b/.github/workflows/publish-elixir.yml
@@ -26,7 +26,8 @@ jobs:
       - name: Verify release tag
         working-directory: adapters/elixir
         run: |
-          VERSION=$(mix run -e 'IO.write(Mix.Project.config()[:version])')
+          VERSION=$(sed -n 's/^[[:space:]]*@version "\([^"]*\)".*/\1/p' mix.exs)
+          test -n "$VERSION"
           test "${{ github.event.release.tag_name }}" = "elixir/v${VERSION}"
       - name: Test package
         working-directory: adapters/elixir


### PR DESCRIPTION
Fix the Elixir release workflow so version verification reads `@version` directly from `mix.exs` instead of capturing `mix run` compilation output.

This is required to recover the failed `elixir/v0.1.0` release. Do not merge without Vishnu's explicit approval.