### PR TITLE
Expose renderer options across language adapters

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Build ASP.NET Core adapter
         run: dotnet build adapters/dotnet/src/Prauga.FlexDoc.AspNetCore/Prauga.FlexDoc.AspNetCore.csproj --configuration Release
 
+      - name: Test ASP.NET Core renderer options
+        run: dotnet run --project adapters/dotnet/tests/Prauga.FlexDoc.AspNetCore.Tests/Prauga.FlexDoc.AspNetCore.Tests.csproj --configuration Release
+
       - name: Pack NuGet release candidate
         run: dotnet pack adapters/dotnet/src/Prauga.FlexDoc.AspNetCore/Prauga.FlexDoc.AspNetCore.csproj --configuration Release --no-build --output /tmp/flexdoc-dotnet
 

--- a/adapters/dotnet/README.md
+++ b/adapters/dotnet/README.md
@@ -32,6 +32,8 @@ app.MapFlexDoc(options =>
 app.Run();
 ```
 
+`FlexDocOptions` also exposes `Expand`, `TryItDefaultServer`, `TryItCredentials`, and `TryItApiClientPersistenceKey`. `Expand` accepts a preset string or string list, while the persistence key accepts a string or `false`; unset values are omitted from renderer options.
+
 FlexDoc serves the docs shell at `/docs` and version-fingerprinted renderer assets beneath `/docs/__flexdoc/`. ASP.NET Core endpoint routing also accepts the equivalent trailing-slash request `/docs/`; CI exercises both forms. The HTML shell is `no-cache`; renderer JS/CSS are immutable and self-hosted.
 
 The integration only needs an OpenAPI JSON URL. It deliberately has no dependency on Swashbuckle, NSwag, or a particular OpenAPI generator.

--- a/adapters/dotnet/src/Prauga.FlexDoc.AspNetCore/FlexDocEndpointRouteBuilderExtensions.cs
+++ b/adapters/dotnet/src/Prauga.FlexDoc.AspNetCore/FlexDocEndpointRouteBuilderExtensions.cs
@@ -82,15 +82,26 @@ public static class FlexDocEndpointRouteBuilderExtensions
         }
     }
 
-    private static string CreateHtml(FlexDocOptions options, string path)
+    internal static string CreateHtml(FlexDocOptions options, string path)
     {
-        var rendererOptions = new
+        var tryIt = new Dictionary<string, object?>
         {
-            contractVersion = "1",
-            title = options.Title,
-            theme = options.Theme,
-            tryIt = new { enabled = options.TryItEnabled },
+            ["enabled"] = options.TryItEnabled,
         };
+        if (options.TryItDefaultServer is not null) tryIt["defaultServer"] = options.TryItDefaultServer;
+        if (options.TryItCredentials is not null) tryIt["credentials"] = options.TryItCredentials;
+        if (options.TryItApiClientPersistenceKey is not null)
+            tryIt["apiClientPersistenceKey"] = options.TryItApiClientPersistenceKey;
+
+        var rendererOptions = new Dictionary<string, object?>
+        {
+            ["contractVersion"] = "1",
+            ["title"] = options.Title,
+            ["theme"] = options.Theme,
+            ["tryIt"] = tryIt,
+        };
+        if (options.Expand is not null) rendererOptions["expand"] = options.Expand;
+
         var specUrl = SafeJson(options.SpecUrl);
         var serializedOptions = SafeJson(rendererOptions);
         var title = HtmlEncoder.Default.Encode(options.Title);
@@ -136,5 +147,18 @@ public static class FlexDocEndpointRouteBuilderExtensions
             throw new ArgumentException("FlexDoc Title cannot be empty.", nameof(options));
         if (options.Theme is not ("system" or "light" or "dark"))
             throw new ArgumentException("FlexDoc Theme must be system, light, or dark.", nameof(options));
+        if (options.TryItCredentials is not null && options.TryItCredentials is not ("omit" or "same-origin" or "include"))
+            throw new ArgumentException("FlexDoc TryItCredentials must be omit, same-origin, or include.", nameof(options));
+        if (options.TryItApiClientPersistenceKey is bool enabled && enabled)
+            throw new ArgumentException("FlexDoc TryItApiClientPersistenceKey supports a string or false.", nameof(options));
+        if (options.TryItApiClientPersistenceKey is not null
+            && options.TryItApiClientPersistenceKey is not string
+            && options.TryItApiClientPersistenceKey is not bool)
+            throw new ArgumentException("FlexDoc TryItApiClientPersistenceKey supports a string or false.", nameof(options));
+        if (options.Expand is not null
+            && options.Expand is not string
+            && options.Expand is not IEnumerable<string>
+            && options.Expand is not JsonElement)
+            throw new ArgumentException("FlexDoc Expand supports a preset string or a string list.", nameof(options));
     }
 }

--- a/adapters/dotnet/src/Prauga.FlexDoc.AspNetCore/FlexDocOptions.cs
+++ b/adapters/dotnet/src/Prauga.FlexDoc.AspNetCore/FlexDocOptions.cs
@@ -17,4 +17,16 @@ public sealed class FlexDocOptions
 
     /// <summary>Whether Try It and the API Client handoff are enabled.</summary>
     public bool TryItEnabled { get; set; } = true;
+
+    /// <summary>Renderer expansion preset or explicit section list. Omit for compact defaults.</summary>
+    public object? Expand { get; set; }
+
+    /// <summary>Default Try It server URL.</summary>
+    public string? TryItDefaultServer { get; set; }
+
+    /// <summary>Fetch credentials mode: omit, same-origin, or include.</summary>
+    public string? TryItCredentials { get; set; }
+
+    /// <summary>API Client persistence key, or false to disable IndexedDB workspace persistence.</summary>
+    public object? TryItApiClientPersistenceKey { get; set; }
 }

--- a/adapters/dotnet/src/Prauga.FlexDoc.AspNetCore/Properties/AssemblyInfo.cs
+++ b/adapters/dotnet/src/Prauga.FlexDoc.AspNetCore/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Prauga.FlexDoc.AspNetCore.Tests")]

--- a/adapters/dotnet/tests/Prauga.FlexDoc.AspNetCore.Tests/Prauga.FlexDoc.AspNetCore.Tests.csproj
+++ b/adapters/dotnet/tests/Prauga.FlexDoc.AspNetCore.Tests/Prauga.FlexDoc.AspNetCore.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>Prauga.FlexDoc.AspNetCore.Tests</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Prauga.FlexDoc.AspNetCore/Prauga.FlexDoc.AspNetCore.csproj" />
+  </ItemGroup>
+</Project>

--- a/adapters/dotnet/tests/Prauga.FlexDoc.AspNetCore.Tests/Program.cs
+++ b/adapters/dotnet/tests/Prauga.FlexDoc.AspNetCore.Tests/Program.cs
@@ -1,0 +1,41 @@
+using System.Text.Json;
+using Prauga.FlexDoc.AspNetCore;
+
+static JsonElement RendererOptions(FlexDocOptions options)
+{
+    var html = FlexDocEndpointRouteBuilderExtensions.CreateHtml(options, "/docs");
+    const string prefix = "window.__FLEXDOC_OPTIONS__=";
+    var start = html.IndexOf(prefix, StringComparison.Ordinal) + prefix.Length;
+    var end = html.IndexOf(";</script>", start, StringComparison.Ordinal);
+    return JsonDocument.Parse(html[start..end]).RootElement.Clone();
+}
+
+static void Check(bool condition, string message)
+{
+    if (!condition) throw new InvalidOperationException(message);
+}
+
+var defaults = RendererOptions(new FlexDocOptions());
+Check(!defaults.TryGetProperty("expand", out _), "expand must be omitted by default");
+Check(defaults.GetProperty("tryIt").GetProperty("enabled").GetBoolean(), "tryIt.enabled must be present");
+
+var configured = new FlexDocOptions
+{
+    Title = "API </script><script>alert(1)</script>",
+    SpecUrl = "/openapi.json?x=</script>",
+    Expand = new[] { "parameters", "tryIt" },
+    TryItDefaultServer = "https://gateway.example.test",
+    TryItCredentials = "include",
+    TryItApiClientPersistenceKey = false,
+};
+var configuredHtml = FlexDocEndpointRouteBuilderExtensions.CreateHtml(configured, "/docs");
+var options = RendererOptions(configured);
+Check(options.GetProperty("expand").GetArrayLength() == 2, "expand list must serialize as JSON array");
+var tryIt = options.GetProperty("tryIt");
+Check(tryIt.GetProperty("defaultServer").GetString() == "https://gateway.example.test", "defaultServer must be nested under tryIt");
+Check(tryIt.GetProperty("credentials").GetString() == "include", "credentials must be nested under tryIt");
+Check(tryIt.GetProperty("apiClientPersistenceKey").ValueKind == JsonValueKind.False, "persistence false must be JSON false");
+Check(!configuredHtml.Contains("</script><script>alert(1)</script>", StringComparison.Ordinal), "title must remain script-safe");
+Check(!configuredHtml.Contains("\"/openapi.json?x=</script>\"", StringComparison.Ordinal), "spec URL must remain script-safe");
+
+Console.WriteLine(".NET FlexDoc renderer options contract passed.");

--- a/adapters/elixir/README.md
+++ b/adapters/elixir/README.md
@@ -11,6 +11,8 @@ plug PraugaFlexDoc.Plug,
   title: "My API"
 ```
 
+The Plug config also accepts `expand`, `try_it_default_server`, `try_it_credentials`, and `try_it_api_client_persistence_key`; expansion may be a preset string or section list, and persistence may be a string or `false`.
+
 ## Phoenix
 
 Phoenix routers can forward directly to the same Plug:

--- a/adapters/elixir/lib/prauga_flexdoc/config.ex
+++ b/adapters/elixir/lib/prauga_flexdoc/config.ex
@@ -4,7 +4,11 @@ defmodule PraugaFlexDoc.Config do
             spec_url: "/openapi.json",
             title: "API Reference",
             theme: "system",
-            try_it_enabled: true
+            try_it_enabled: true,
+            expand: nil,
+            try_it_default_server: nil,
+            try_it_credentials: nil,
+            try_it_api_client_persistence_key: nil
 
   def new(opts \\ []) do
     config = struct!(__MODULE__, Map.new(opts))
@@ -12,6 +16,16 @@ defmodule PraugaFlexDoc.Config do
     path = if path == "/", do: "/docs", else: path
     theme = to_string(config.theme)
     unless theme in ["system", "light", "dark"], do: raise(ArgumentError, "FlexDoc theme must be system, light, or dark")
+
+    if config.try_it_credentials not in [nil, "omit", "same-origin", "include"] do
+      raise ArgumentError, "FlexDoc Try It credentials must be omit, same-origin, or include"
+    end
+
+    persistence_key = config.try_it_api_client_persistence_key
+    unless is_nil(persistence_key) or persistence_key == false or is_binary(persistence_key) do
+      raise ArgumentError, "FlexDoc API Client persistence key must be a string, false, or nil"
+    end
+
     %{config | path: path, theme: theme}
   end
 end

--- a/adapters/elixir/lib/prauga_flexdoc/plug.ex
+++ b/adapters/elixir/lib/prauga_flexdoc/plug.ex
@@ -24,12 +24,20 @@ defmodule PraugaFlexDoc.Plug do
   end
 
   defp docs(conn, config) do
-    options = %{
-      contractVersion: "1",
-      title: config.title,
-      theme: config.theme,
-      tryIt: %{enabled: config.try_it_enabled}
-    }
+    try_it =
+      %{enabled: config.try_it_enabled}
+      |> maybe_put(:defaultServer, config.try_it_default_server)
+      |> maybe_put(:credentials, config.try_it_credentials)
+      |> maybe_put(:apiClientPersistenceKey, config.try_it_api_client_persistence_key)
+
+    options =
+      %{
+        contractVersion: "1",
+        title: config.title,
+        theme: config.theme,
+        tryIt: try_it
+      }
+      |> maybe_put(:expand, config.expand)
 
     html = """
     <!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover"><title>#{escape_html(config.title)}</title><link rel="stylesheet" href="#{config.path}/__flexdoc/renderer.css?v=#{@fingerprint}"></head><body><div id="flexdoc-root"></div><script>window.__FLEXDOC_SPEC_URL__=#{safe_json(config.spec_url)};window.__FLEXDOC_OPTIONS__=#{safe_json(options)};</script><script src="#{config.path}/__flexdoc/renderer.js?v=#{@fingerprint}"></script><script>(async function(){const root=document.getElementById('flexdoc-root');try{const baseUri=new URL(window.__FLEXDOC_SPEC_URL__,window.location.href).toString();const response=await fetch(baseUri);if(!response.ok)throw new Error('Unable to load OpenAPI specification: HTTP '+response.status);const spec=await response.json();const config={spec:spec,options:window.__FLEXDOC_OPTIONS__||{},baseUri:baseUri};if(window.FlexDocStandalone.mountAsync)await window.FlexDocStandalone.mountAsync(root,config);else window.FlexDocStandalone.mount(root,config);}catch(error){root.textContent=error instanceof Error?error.message:String(error);}})();</script></body></html>
@@ -40,6 +48,9 @@ defmodule PraugaFlexDoc.Plug do
     |> put_resp_header("cache-control", "no-cache")
     |> send_resp(200, html)
   end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
 
   defp asset(conn, body, content_type) do
     conn

--- a/adapters/elixir/test/plug_test.exs
+++ b/adapters/elixir/test/plug_test.exs
@@ -6,6 +6,11 @@ defmodule PraugaFlexDoc.PlugTest do
 
   @opts FlexDocPlug.init(path: "/reference", spec_url: "/openapi.json", title: "Plug <API>")
 
+  defp renderer_options(body) do
+    [_, json] = Regex.run(~r/window\.__FLEXDOC_OPTIONS__=(.*?);<\/script>/, body)
+    Jason.decode!(json)
+  end
+
   test "serves docs and packaged renderer assets" do
     docs = conn(:get, "/reference") |> FlexDocPlug.call(@opts)
     assert docs.status == 200
@@ -13,10 +18,50 @@ defmodule PraugaFlexDoc.PlugTest do
     assert docs.resp_body =~ "Plug &lt;API&gt;"
     assert docs.resp_body =~ ~s(window.__FLEXDOC_SPEC_URL__="/openapi.json")
 
+    options = renderer_options(docs.resp_body)
+    assert options["tryIt"]["enabled"] == true
+    refute Map.has_key?(options, "expand")
+
     js = conn(:get, "/reference/__flexdoc/renderer.js") |> FlexDocPlug.call(@opts)
     assert js.status == 200
     assert get_resp_header(js, "cache-control") == ["public, max-age=31536000, immutable"]
     assert byte_size(js.resp_body) > 1000
+  end
+
+  test "injects expansion and nested Try It settings" do
+    opts =
+      FlexDocPlug.init(
+        expand: "documentation",
+        try_it_default_server: "https://api.example.test",
+        try_it_credentials: "include",
+        try_it_api_client_persistence_key: false
+      )
+
+    docs = conn(:get, "/docs") |> FlexDocPlug.call(opts)
+    options = renderer_options(docs.resp_body)
+
+    assert options["expand"] == "documentation"
+    assert options["tryIt"]["enabled"] == true
+    assert options["tryIt"]["defaultServer"] == "https://api.example.test"
+    assert options["tryIt"]["credentials"] == "include"
+    assert options["tryIt"]["apiClientPersistenceKey"] == false
+
+    list_opts = FlexDocPlug.init(expand: ["parameters", "tryIt"])
+    list_docs = conn(:get, "/docs") |> FlexDocPlug.call(list_opts)
+    assert renderer_options(list_docs.resp_body)["expand"] == ["parameters", "tryIt"]
+  end
+
+  test "keeps title and spec JSON script safe" do
+    opts =
+      FlexDocPlug.init(
+        spec_url: "</script><script>alert('spec')</script>",
+        title: "</script><script>alert('title')</script>"
+      )
+
+    docs = conn(:get, "/docs") |> FlexDocPlug.call(opts)
+    refute docs.resp_body =~ "</script><script>alert('spec')</script>"
+    refute docs.resp_body =~ "</script><script>alert('title')</script>"
+    assert docs.resp_body =~ "\\u003c/script\\u003e"
   end
 
   test "returns 404 outside the configured mount" do

--- a/adapters/go/README.md
+++ b/adapters/go/README.md
@@ -15,6 +15,8 @@ http.Handle("/docs", flexdoc.Handler(flexdoc.Config{
 }))
 ```
 
+`Config` also accepts `Expand` (a preset string or `[]string`), `TryItDefaultServer`, `TryItCredentials`, and `TryItAPIClientPersistenceKey` (a string or `false`); unset values are omitted from `window.__FLEXDOC_OPTIONS__`.
+
 For code-first generators such as Huma, pass the generated OpenAPI document directly:
 
 ```go

--- a/adapters/go/flexdoc.go
+++ b/adapters/go/flexdoc.go
@@ -16,11 +16,15 @@ import (
 var embeddedRenderer embed.FS
 
 type Config struct {
-    Path         string
-    SpecURL      string
-    Title        string
-    Theme        string
-    TryItEnabled bool
+    Path                          string
+    SpecURL                       string
+    Title                         string
+    Theme                         string
+    TryItEnabled                  bool
+    Expand                        any
+    TryItDefaultServer            string
+    TryItCredentials              string
+    TryItAPIClientPersistenceKey  any
 }
 
 type handler struct { cfg Config; assets fs.FS; spec []byte; rendererVersion string }
@@ -98,7 +102,14 @@ func safeJSON(value any) string {
 }
 
 func (h *handler) html() string {
-    options := map[string]any{"contractVersion":"1", "title":h.cfg.Title, "theme":h.cfg.Theme, "tryIt":map[string]bool{"enabled":h.cfg.TryItEnabled}}
+    tryIt := map[string]any{"enabled": h.cfg.TryItEnabled}
+    if h.cfg.TryItDefaultServer != "" { tryIt["defaultServer"] = h.cfg.TryItDefaultServer }
+    if h.cfg.TryItCredentials != "" { tryIt["credentials"] = h.cfg.TryItCredentials }
+    if h.cfg.TryItAPIClientPersistenceKey != nil { tryIt["apiClientPersistenceKey"] = h.cfg.TryItAPIClientPersistenceKey }
+
+    options := map[string]any{"contractVersion":"1", "title":h.cfg.Title, "theme":h.cfg.Theme, "tryIt":tryIt}
+    if h.cfg.Expand != nil { options["expand"] = h.cfg.Expand }
+
     base := path.Clean(h.cfg.Path)
     return fmt.Sprintf(`<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover"><title>%s</title><link rel="stylesheet" href="%s/__flexdoc/renderer.css?v=%s"></head><body><div id="flexdoc-root"></div><script>window.__FLEXDOC_SPEC_URL__=%s;window.__FLEXDOC_OPTIONS__=%s;</script><script src="%s/__flexdoc/renderer.js?v=%s"></script><script>(async function(){const root=document.getElementById('flexdoc-root');try{const baseUri=new URL(window.__FLEXDOC_SPEC_URL__,window.location.href).toString();const response=await fetch(baseUri);if(!response.ok)throw new Error('Unable to load OpenAPI specification: HTTP '+response.status);const spec=await response.json();const config={spec:spec,options:window.__FLEXDOC_OPTIONS__||{},baseUri:baseUri};if(window.FlexDocStandalone.mountAsync)await window.FlexDocStandalone.mountAsync(root,config);else window.FlexDocStandalone.mount(root,config);}catch(error){root.textContent=error instanceof Error?error.message:String(error);}})();</script></body></html>`, html.EscapeString(h.cfg.Title), base, h.rendererVersion, safeJSON(h.cfg.SpecURL), safeJSON(options), base, h.rendererVersion)
 }

--- a/adapters/go/flexdoc_test.go
+++ b/adapters/go/flexdoc_test.go
@@ -8,6 +8,26 @@ import (
     "testing/fstest"
 )
 
+func testAssets() fstest.MapFS {
+    return fstest.MapFS{
+        "flexdoc.standalone.js": &fstest.MapFile{Data: []byte("window.FlexDocStandalone={};")},
+        "flexdoc.standalone.css": &fstest.MapFile{Data: []byte("body{}")},
+    }
+}
+
+func optionsFromHTML(t *testing.T, body string) map[string]any {
+    t.Helper()
+    const prefix = "window.__FLEXDOC_OPTIONS__="
+    start := strings.Index(body, prefix)
+    if start < 0 { t.Fatal("renderer options missing") }
+    rest := body[start+len(prefix):]
+    end := strings.Index(rest, ";</script>")
+    if end < 0 { t.Fatal("renderer options terminator missing") }
+    var options map[string]any
+    if err := json.Unmarshal([]byte(rest[:end]), &options); err != nil { t.Fatalf("decode renderer options: %v", err) }
+    return options
+}
+
 func TestHandlerServesBundledAssets(t *testing.T) {
     h := Handler(Config{Path:"/reference", SpecURL:"/openapi.json", Title:"API", Theme:"dark", TryItEnabled:true})
     rec := httptest.NewRecorder()
@@ -16,11 +36,7 @@ func TestHandlerServesBundledAssets(t *testing.T) {
 }
 
 func TestHandlerWithAssetsIsSafe(t *testing.T) {
-    assets := fstest.MapFS{
-        "flexdoc.standalone.js": &fstest.MapFile{Data: []byte("window.FlexDocStandalone={};")},
-        "flexdoc.standalone.css": &fstest.MapFile{Data: []byte("body{}")},
-    }
-    h := HandlerWithAssets(Config{Path:"/reference", SpecURL:"/openapi.json", Title:"</script><script>alert(1)</script>", Theme:"dark", TryItEnabled:true}, assets)
+    h := HandlerWithAssets(Config{Path:"/reference", SpecURL:"/openapi.json?x=</script>", Title:"</script><script>alert(1)</script>", Theme:"dark", TryItEnabled:true}, testAssets())
     rec := httptest.NewRecorder()
     h.ServeHTTP(rec, httptest.NewRequest("GET", "/reference", nil))
     if rec.Code != 200 { t.Fatalf("status = %d", rec.Code) }
@@ -28,6 +44,42 @@ func TestHandlerWithAssetsIsSafe(t *testing.T) {
     if !strings.Contains(body, "/reference/__flexdoc/renderer.js?v=") { t.Fatal("versioned renderer route missing") }
     if !strings.Contains(body, "/reference/__flexdoc/renderer.css?v=") { t.Fatal("versioned renderer stylesheet missing") }
     if strings.Contains(body, "</script><script>alert(1)</script>") { t.Fatal("unsafe title rendered") }
+    if strings.Contains(body, `"/openapi.json?x=</script>"`) { t.Fatal("unsafe spec URL rendered") }
+}
+
+func TestRendererOptionsOmitOptionalFields(t *testing.T) {
+    h := HandlerWithAssets(Config{Path:"/reference", SpecURL:"/openapi.json", Title:"API", Theme:"dark", TryItEnabled:true}, testAssets())
+    rec := httptest.NewRecorder()
+    h.ServeHTTP(rec, httptest.NewRequest("GET", "/reference", nil))
+    options := optionsFromHTML(t, rec.Body.String())
+    if _, ok := options["expand"]; ok { t.Fatal("expand should be omitted") }
+    tryIt := options["tryIt"].(map[string]any)
+    if tryIt["enabled"] != true { t.Fatalf("tryIt.enabled = %#v", tryIt["enabled"]) }
+    if len(tryIt) != 1 { t.Fatalf("unexpected Try It options: %#v", tryIt) }
+}
+
+func TestRendererOptionsSerializeExpandAndTryItSettings(t *testing.T) {
+    cases := []struct { name string; expand any }{
+        {"preset", "documentation"},
+        {"sections", []string{"parameters", "tryIt"}},
+    }
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            h := HandlerWithAssets(Config{
+                Path:"/reference", SpecURL:"/openapi.json", Title:"API", Theme:"dark", TryItEnabled:true,
+                Expand:tc.expand, TryItDefaultServer:"https://gateway.example.test", TryItCredentials:"include", TryItAPIClientPersistenceKey:false,
+            }, testAssets())
+            rec := httptest.NewRecorder()
+            h.ServeHTTP(rec, httptest.NewRequest("GET", "/reference", nil))
+            options := optionsFromHTML(t, rec.Body.String())
+            expectedExpand, _ := json.Marshal(tc.expand)
+            actualExpand, _ := json.Marshal(options["expand"])
+            if string(actualExpand) != string(expectedExpand) { t.Fatalf("expand = %s, want %s", actualExpand, expectedExpand) }
+            tryIt := options["tryIt"].(map[string]any)
+            if tryIt["enabled"] != true || tryIt["defaultServer"] != "https://gateway.example.test" || tryIt["credentials"] != "include" { t.Fatalf("Try It options = %#v", tryIt) }
+            if value, ok := tryIt["apiClientPersistenceKey"].(bool); !ok || value { t.Fatalf("persistence key = %#v", tryIt["apiClientPersistenceKey"]) }
+        })
+    }
 }
 
 func TestHandlerFromOpenAPIServesGeneratedSpecAndDocs(t *testing.T) {

--- a/adapters/java-jaxrs/README.md
+++ b/adapters/java-jaxrs/README.md
@@ -2,6 +2,8 @@
 
 `com.prauga.flexdoc:flexdoc-jaxrs` is a thin Jakarta REST/JAX-RS wrapper around `flexdoc-jvm`. Provide a `FlexDocHost` through CDI and register `FlexDocJaxRsResource`; the default resource serves `/docs` and its local renderer assets.
 
+Renderer settings are configured on the shared JVM `FlexDocConfig`, including `expand(...)`/`expandSections(...)`, `tryItDefaultServer(...)`, `tryItCredentials(...)`, and `tryItApiClientPersistenceKey(...)`; JAX-RS does not maintain a second options model.
+
 `FlexDocJaxRsResource` uses `@Path("/docs")` because Jakarta REST resource paths are annotation values and therefore compile-time constants. `FlexDocConfig.path()` cannot dynamically change that class-level route. For a custom path, subclass the resource (or create the same thin resource in your application) with a new `@Path` while keeping the injected `FlexDocHost` configured to the same path:
 
 ```java

--- a/adapters/java-jvm/README.md
+++ b/adapters/java-jvm/README.md
@@ -11,6 +11,8 @@ FlexDocHost host = new FlexDocHost(
         .build());
 ```
 
+The builder also exposes `expand(...)` or `expandSections(...)`, `tryItDefaultServer(...)`, `tryItCredentials(...)`, and `tryItApiClientPersistenceKey(...)`; the persistence key may be a string or `false`, and unset fields are omitted from `window.__FLEXDOC_OPTIONS__`.
+
 An HTTP framework only needs to map three responses from the host: `documentation()`, `rendererJavaScript()`, and `rendererCss()`.
 
 For Guice or Governator-style applications, bind a configured `FlexDocHost` as a singleton and have the application's existing HTTP layer translate `FlexDocHttpResponse` into its native response type. Governator is built around Guice lifecycle/DI, so no renderer-specific Governator integration is required.

--- a/adapters/java-jvm/src/main/java/com/prauga/flexdoc/jvm/FlexDocConfig.java
+++ b/adapters/java-jvm/src/main/java/com/prauga/flexdoc/jvm/FlexDocConfig.java
@@ -1,15 +1,53 @@
 package com.prauga.flexdoc.jvm;
 
+import java.util.List;
+
 /** Immutable framework-neutral configuration for a FlexDoc host. */
-public record FlexDocConfig(String path, String specUrl, String title, String theme, boolean tryItEnabled) {
+public record FlexDocConfig(
+    String path,
+    String specUrl,
+    String title,
+    String theme,
+    boolean tryItEnabled,
+    Object expand,
+    String tryItDefaultServer,
+    String tryItCredentials,
+    Object tryItApiClientPersistenceKey) {
+  /** Preserves the original public constructor while leaving new renderer settings unset. */
+  public FlexDocConfig(String path, String specUrl, String title, String theme, boolean tryItEnabled) {
+    this(path, specUrl, title, theme, tryItEnabled, null, null, null, null);
+  }
+
   /** Creates validated configuration and normalizes the documentation path. */
   public FlexDocConfig {
     path = normalizePath(path);
     specUrl = blankToNull(specUrl);
     title = title == null || title.isBlank() ? "API Documentation" : title;
     theme = theme == null || theme.isBlank() ? "light" : theme;
+    tryItDefaultServer = blankToNull(tryItDefaultServer);
+    tryItCredentials = blankToNull(tryItCredentials);
     if (!theme.equals("system") && !theme.equals("light") && !theme.equals("dark")) {
       throw new IllegalArgumentException("FlexDoc theme must be system, light, or dark");
+    }
+    if (tryItCredentials != null
+        && !tryItCredentials.equals("omit")
+        && !tryItCredentials.equals("same-origin")
+        && !tryItCredentials.equals("include")) {
+      throw new IllegalArgumentException("FlexDoc Try It credentials must be omit, same-origin, or include");
+    }
+    if (expand != null && !(expand instanceof String) && !(expand instanceof List<?>)) {
+      throw new IllegalArgumentException("FlexDoc expand must be a preset string or section list");
+    }
+    if (expand instanceof List<?> values && values.stream().anyMatch(value -> !(value instanceof String))) {
+      throw new IllegalArgumentException("FlexDoc expand section lists must contain strings");
+    }
+    if (tryItApiClientPersistenceKey != null
+        && !(tryItApiClientPersistenceKey instanceof String)
+        && !(tryItApiClientPersistenceKey instanceof Boolean)) {
+      throw new IllegalArgumentException("FlexDoc API Client persistence key must be a string or false");
+    }
+    if (Boolean.TRUE.equals(tryItApiClientPersistenceKey)) {
+      throw new IllegalArgumentException("FlexDoc API Client persistence key supports false, not true");
     }
   }
 
@@ -37,12 +75,33 @@ public record FlexDocConfig(String path, String specUrl, String title, String th
     private String title = "API Documentation";
     private String theme = "light";
     private boolean tryItEnabled = true;
+    private Object expand;
+    private String tryItDefaultServer;
+    private String tryItCredentials;
+    private Object tryItApiClientPersistenceKey;
 
     public Builder path(String value) { path = value; return this; }
     public Builder specUrl(String value) { specUrl = value; return this; }
     public Builder title(String value) { title = value; return this; }
     public Builder theme(String value) { theme = value; return this; }
     public Builder tryItEnabled(boolean value) { tryItEnabled = value; return this; }
-    public FlexDocConfig build() { return new FlexDocConfig(path, specUrl, title, theme, tryItEnabled); }
+    public Builder expand(String value) { expand = value; return this; }
+    public Builder expandSections(List<String> value) { expand = value == null ? null : List.copyOf(value); return this; }
+    public Builder tryItDefaultServer(String value) { tryItDefaultServer = value; return this; }
+    public Builder tryItCredentials(String value) { tryItCredentials = value; return this; }
+    public Builder tryItApiClientPersistenceKey(String value) { tryItApiClientPersistenceKey = value; return this; }
+    public Builder tryItApiClientPersistenceKey(boolean value) { tryItApiClientPersistenceKey = value; return this; }
+    public FlexDocConfig build() {
+      return new FlexDocConfig(
+          path,
+          specUrl,
+          title,
+          theme,
+          tryItEnabled,
+          expand,
+          tryItDefaultServer,
+          tryItCredentials,
+          tryItApiClientPersistenceKey);
+    }
   }
 }

--- a/adapters/java-jvm/src/main/java/com/prauga/flexdoc/jvm/FlexDocHost.java
+++ b/adapters/java-jvm/src/main/java/com/prauga/flexdoc/jvm/FlexDocHost.java
@@ -6,6 +6,8 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Objects;
 
 /** Framework-neutral FlexDoc host that serves the documentation shell and canonical renderer assets. */
@@ -41,9 +43,23 @@ public final class FlexDocHost {
     boolean hasInlineSpec = supplied != null && !supplied.isBlank();
     String spec = hasInlineSpec ? safeInlineJson(supplied) : "null";
     String specUrl = jsonString(hasInlineSpec ? null : config.specUrl());
-    String options = "{\"contractVersion\":\"1\",\"title\":" + jsonString(config.title())
-        + ",\"theme\":" + jsonString(config.theme())
-        + ",\"tryIt\":{\"enabled\":" + config.tryItEnabled() + "}}";
+
+    Map<String, Object> tryIt = new LinkedHashMap<>();
+    tryIt.put("enabled", config.tryItEnabled());
+    if (config.tryItDefaultServer() != null) tryIt.put("defaultServer", config.tryItDefaultServer());
+    if (config.tryItCredentials() != null) tryIt.put("credentials", config.tryItCredentials());
+    if (config.tryItApiClientPersistenceKey() != null) {
+      tryIt.put("apiClientPersistenceKey", config.tryItApiClientPersistenceKey());
+    }
+
+    Map<String, Object> rendererOptions = new LinkedHashMap<>();
+    rendererOptions.put("contractVersion", "1");
+    rendererOptions.put("title", config.title());
+    rendererOptions.put("theme", config.theme());
+    rendererOptions.put("tryIt", tryIt);
+    if (config.expand() != null) rendererOptions.put("expand", config.expand());
+    String options = jsonValue(rendererOptions);
+
     String base = escapeHtmlAttribute(config.path());
     String html = "<!doctype html><html><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width,initial-scale=1,viewport-fit=cover\">"
         + "<meta name=\"color-scheme\" content=\"light dark\"><title>" + escapeHtml(config.title()) + "</title><link rel=\"stylesheet\" href=\"" + base + "/__flexdoc/renderer.css?v=" + fingerprint + "\"></head>"
@@ -90,6 +106,36 @@ public final class FlexDocHost {
   private static String safeInlineJson(String json) {
     return json.replace("<", "\\u003c").replace(">", "\\u003e").replace("&", "\\u0026")
         .replace("\u2028", "\\u2028").replace("\u2029", "\\u2029");
+  }
+
+  private static String jsonValue(Object value) {
+    if (value == null) return "null";
+    if (value instanceof String string) return jsonString(string);
+    if (value instanceof Boolean || value instanceof Number) return value.toString();
+    if (value instanceof Map<?, ?> map) {
+      StringBuilder out = new StringBuilder("{");
+      boolean first = true;
+      for (Map.Entry<?, ?> entry : map.entrySet()) {
+        if (!(entry.getKey() instanceof String key)) {
+          throw new IllegalArgumentException("JSON object keys must be strings");
+        }
+        if (!first) out.append(',');
+        first = false;
+        out.append(jsonString(key)).append(':').append(jsonValue(entry.getValue()));
+      }
+      return out.append('}').toString();
+    }
+    if (value instanceof Iterable<?> values) {
+      StringBuilder out = new StringBuilder("[");
+      boolean first = true;
+      for (Object item : values) {
+        if (!first) out.append(',');
+        first = false;
+        out.append(jsonValue(item));
+      }
+      return out.append(']').toString();
+    }
+    throw new IllegalArgumentException("Unsupported JSON value type: " + value.getClass().getName());
   }
 
   private static String jsonString(String value) {

--- a/adapters/java-jvm/src/test/java/com/prauga/flexdoc/jvm/FlexDocHostTest.java
+++ b/adapters/java-jvm/src/test/java/com/prauga/flexdoc/jvm/FlexDocHostTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class FlexDocHostTest {
@@ -15,6 +16,8 @@ class FlexDocHostTest {
     assertTrue(html.contains("/docs/__flexdoc/renderer.js?v="));
     assertTrue(html.contains("window.__FLEXDOC_SPEC__=null"));
     assertTrue(html.contains("window.__FLEXDOC_SPEC_URL__=\"/openapi.json\""));
+    assertTrue(html.contains("\"tryIt\":{\"enabled\":true}"));
+    assertFalse(html.contains("\"expand\":"));
     assertTrue(host.rendererJavaScript().cacheControl().contains("immutable"));
     assertTrue(host.rendererCss().cacheControl().contains("immutable"));
     assertTrue(host.rendererJavaScript().body().length > 1000);
@@ -23,10 +26,30 @@ class FlexDocHostTest {
   }
 
   @Test
+  void serializesRendererSettingsStructurally() throws Exception {
+    FlexDocHost presetHost = new FlexDocHost(
+        FlexDocConfig.builder()
+            .expand("documentation")
+            .tryItDefaultServer("https://api.example.test")
+            .tryItCredentials("include")
+            .tryItApiClientPersistenceKey(false)
+            .build());
+    String presetHtml = presetHost.documentation().bodyUtf8();
+
+    assertTrue(presetHtml.contains("\"expand\":\"documentation\""));
+    assertTrue(presetHtml.contains("\"tryIt\":{\"enabled\":true,\"defaultServer\":\"https://api.example.test\",\"credentials\":\"include\",\"apiClientPersistenceKey\":false}"));
+    assertFalse(presetHtml.contains("\"apiClientPersistenceKey\":\"false\""));
+
+    FlexDocHost listHost = new FlexDocHost(
+        FlexDocConfig.builder().expandSections(List.of("parameters", "tryIt")).build());
+    assertTrue(listHost.documentation().bodyUtf8().contains("\"expand\":[\"parameters\",\"tryIt\"]"));
+  }
+
+  @Test
   void safelyEmbedsInlineSpecAndCustomPath() throws Exception {
     String json = "{\"openapi\":\"3.1.0\",\"x-test\":\"</script><script>alert(1)</script>\"}";
     FlexDocHost host = new FlexDocHost(
-        FlexDocConfig.builder().path("reference/").title("Example <API>").build(),
+        FlexDocConfig.builder().path("reference/").specUrl("</script><script>alert(2)</script>").title("Example <API>").build(),
         () -> json);
     String html = host.documentation().bodyUtf8();
 
@@ -34,6 +57,7 @@ class FlexDocHostTest {
     assertTrue(html.contains("Example &lt;API&gt;"));
     assertTrue(html.contains("window.__FLEXDOC_SPEC_URL__=null"));
     assertFalse(html.contains("</script><script>alert(1)</script>"));
+    assertFalse(html.contains("</script><script>alert(2)</script>"));
     assertTrue(html.contains("\\u003c/script\\u003e"));
   }
 }

--- a/adapters/java-spring/README.md
+++ b/adapters/java-spring/README.md
@@ -29,7 +29,14 @@ flexdoc:
   title: My API
   theme: dark
   try-it-enabled: true
+  expand: documentation
+  # expand-sections: [parameters, tryIt] # list wins over expand when both are set
+  try-it-default-server: https://api.example.com
+  try-it-credentials: include
+  try-it-api-client-persistence-key: my-api-workspace # use false to disable persistence
 ```
+
+The four renderer settings (`expand`, Try It default server/credentials, and API Client persistence key) are omitted when unset, preserving the renderer's compact/default behavior.
 
 The renderer assets are served locally at `/docs/__flexdoc/*`, so the integration has no runtime CDN dependency.
 

--- a/adapters/java-spring/src/main/java/com/prauga/flexdoc/spring/FlexDocProperties.java
+++ b/adapters/java-spring/src/main/java/com/prauga/flexdoc/spring/FlexDocProperties.java
@@ -1,6 +1,7 @@
 package com.prauga.flexdoc.spring;
 
 import com.prauga.flexdoc.jvm.FlexDocConfig;
+import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /** Configuration properties for the self-hosted FlexDoc Spring Boot integration. */
@@ -13,6 +14,11 @@ public class FlexDocProperties {
   private String title = "API Documentation";
   private String theme = "light";
   private boolean tryItEnabled = true;
+  private String expand = "";
+  private List<String> expandSections = List.of();
+  private String tryItDefaultServer = "";
+  private String tryItCredentials = "";
+  private Object tryItApiClientPersistenceKey;
 
   public boolean isEnabled() { return enabled; }
   public void setEnabled(boolean enabled) { this.enabled = enabled; }
@@ -28,8 +34,40 @@ public class FlexDocProperties {
   public void setTheme(String theme) { this.theme = theme; }
   public boolean isTryItEnabled() { return tryItEnabled; }
   public void setTryItEnabled(boolean tryItEnabled) { this.tryItEnabled = tryItEnabled; }
+  public String getExpand() { return expand; }
+  public void setExpand(String expand) { this.expand = expand; }
+  public List<String> getExpandSections() { return expandSections; }
+  public void setExpandSections(List<String> expandSections) { this.expandSections = expandSections == null ? List.of() : List.copyOf(expandSections); }
+  public String getTryItDefaultServer() { return tryItDefaultServer; }
+  public void setTryItDefaultServer(String tryItDefaultServer) { this.tryItDefaultServer = tryItDefaultServer; }
+  public String getTryItCredentials() { return tryItCredentials; }
+  public void setTryItCredentials(String tryItCredentials) { this.tryItCredentials = tryItCredentials; }
+  public Object getTryItApiClientPersistenceKey() { return tryItApiClientPersistenceKey; }
+  public void setTryItApiClientPersistenceKey(Object tryItApiClientPersistenceKey) { this.tryItApiClientPersistenceKey = tryItApiClientPersistenceKey; }
 
   FlexDocConfig toConfig() {
-    return FlexDocConfig.builder().path(path).specUrl(specUrl).title(title).theme(theme).tryItEnabled(tryItEnabled).build();
+    FlexDocConfig.Builder builder = FlexDocConfig.builder()
+        .path(path)
+        .specUrl(specUrl)
+        .title(title)
+        .theme(theme)
+        .tryItEnabled(tryItEnabled)
+        .tryItDefaultServer(tryItDefaultServer)
+        .tryItCredentials(tryItCredentials);
+
+    if (expandSections != null && !expandSections.isEmpty()) builder.expandSections(expandSections);
+    else if (expand != null && !expand.isBlank()) builder.expand(expand);
+
+    Object persistenceKey = tryItApiClientPersistenceKey;
+    if (persistenceKey instanceof String stringValue) {
+      if (stringValue.equalsIgnoreCase("false")) builder.tryItApiClientPersistenceKey(false);
+      else if (!stringValue.isBlank()) builder.tryItApiClientPersistenceKey(stringValue);
+    } else if (persistenceKey instanceof Boolean booleanValue) {
+      builder.tryItApiClientPersistenceKey(booleanValue);
+    } else if (persistenceKey != null) {
+      throw new IllegalArgumentException("FlexDoc API Client persistence key must be a string or false");
+    }
+
+    return builder.build();
   }
 }

--- a/adapters/java-spring/src/test/java/com/prauga/flexdoc/spring/FlexDocControllerTest.java
+++ b/adapters/java-spring/src/test/java/com/prauga/flexdoc/spring/FlexDocControllerTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.prauga.flexdoc.jvm.FlexDocHost;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -19,7 +20,30 @@ class FlexDocControllerTest {
     assertThat(html).contains("/docs/__flexdoc/renderer.js?v=");
     assertThat(html).contains("window.__FLEXDOC_SPEC__=null");
     assertThat(html).contains("window.__FLEXDOC_SPEC_URL__=\"/v3/api-docs\"");
+    assertThat(html).contains("\"tryIt\":{\"enabled\":true}");
+    assertThat(html).doesNotContain("\"expand\":");
     assertThat(html).contains("FlexDocStandalone.mountAsync");
+  }
+
+  @Test
+  void forwardsRendererPropertiesWithSectionListPrecedence() throws Exception {
+    FlexDocProperties properties = new FlexDocProperties();
+    properties.setExpand("all");
+    properties.setExpandSections(List.of("parameters", "tryIt"));
+    properties.setTryItDefaultServer("https://api.example.test");
+    properties.setTryItCredentials("include");
+    properties.setTryItApiClientPersistenceKey("false");
+
+    FlexDocHost host = new FlexDocHost(properties.toConfig());
+    FlexDocController controller = new FlexDocController(properties, host);
+    String html = new String(controller.documentation().getBody(), StandardCharsets.UTF_8);
+
+    assertThat(html).contains("\"expand\":[\"parameters\",\"tryIt\"]");
+    assertThat(html).doesNotContain("\"expand\":\"all\"");
+    assertThat(html).contains("\"defaultServer\":\"https://api.example.test\"");
+    assertThat(html).contains("\"credentials\":\"include\"");
+    assertThat(html).contains("\"apiClientPersistenceKey\":false");
+    assertThat(html).doesNotContain("\"apiClientPersistenceKey\":\"false\"");
   }
 
   @Test

--- a/adapters/php/README.md
+++ b/adapters/php/README.md
@@ -13,11 +13,13 @@ use Prauga\FlexDoc\FlexDocHost;
 $host = new FlexDocHost(new FlexDocConfig(path: '/docs', specUrl: '/openapi.json', title: 'My API'));
 ```
 
+`FlexDocConfig` also accepts `expand`, `tryItDefaultServer`, `tryItCredentials`, and `tryItApiClientPersistenceKey`; `expand` may be a preset string or section array, and the persistence key may be a string or `false`.
+
 Map `responseForPath()` or the three explicit response methods through your HTTP framework.
 
 ## Laravel
 
-Laravel package auto-discovery loads `FlexDocServiceProvider`, which binds `FlexDocHost` and registers the docs and renderer routes. Configure `flexdoc.path`, `flexdoc.spec_url`, `flexdoc.title`, `flexdoc.theme`, and `flexdoc.try_it_enabled` in the application config. `FLEXDOC_TRY_IT=false` is parsed as a boolean and disables Try It. `LaravelFlexDoc::register($router, $host)` is also available for manual routing.
+Laravel package auto-discovery loads `FlexDocServiceProvider`, which binds `FlexDocHost` and registers the docs and renderer routes. Configure `flexdoc.path`, `flexdoc.spec_url`, `flexdoc.title`, `flexdoc.theme`, and `flexdoc.try_it_enabled` in the application config. The adapter also accepts `expand`, `try_it_default_server`, `try_it_credentials`, and `try_it_api_client_persistence_key`; unset renderer settings are omitted. `FLEXDOC_TRY_IT=false` is parsed as a boolean and disables Try It. `LaravelFlexDoc::register($router, $host)` is also available for manual routing.
 
 Laravel normalizes the request path used for route matching, so the single docs route serves both `/docs` and `/docs/`; the package integration tests dispatch both forms explicitly.
 

--- a/adapters/php/config/flexdoc.php
+++ b/adapters/php/config/flexdoc.php
@@ -10,4 +10,8 @@ return [
         FILTER_VALIDATE_BOOLEAN,
         FILTER_NULL_ON_FAILURE,
     ) ?? true,
+    'expand' => env('FLEXDOC_EXPAND'),
+    'try_it_default_server' => env('FLEXDOC_TRY_IT_DEFAULT_SERVER'),
+    'try_it_credentials' => env('FLEXDOC_TRY_IT_CREDENTIALS'),
+    'try_it_api_client_persistence_key' => env('FLEXDOC_API_CLIENT_PERSISTENCE_KEY'),
 ];

--- a/adapters/php/src/FlexDocConfig.php
+++ b/adapters/php/src/FlexDocConfig.php
@@ -8,17 +8,28 @@ final readonly class FlexDocConfig
 {
     public string $path;
 
+    /**
+     * @param string|array<int, string>|null $expand
+     * @param string|false|null $tryItApiClientPersistenceKey
+     */
     public function __construct(
         string $path = '/docs',
         public string $specUrl = '/openapi.json',
         public string $title = 'API Reference',
         public string $theme = 'system',
         public bool $tryItEnabled = true,
+        public string|array|null $expand = null,
+        public ?string $tryItDefaultServer = null,
+        public ?string $tryItCredentials = null,
+        public string|false|null $tryItApiClientPersistenceKey = null,
     ) {
         $normalized = '/' . trim($path, '/');
         $this->path = $normalized === '/' ? '/docs' : $normalized;
         if (!in_array($theme, ['system', 'light', 'dark'], true)) {
             throw new \InvalidArgumentException('FlexDoc theme must be system, light, or dark.');
+        }
+        if ($tryItCredentials !== null && !in_array($tryItCredentials, ['omit', 'same-origin', 'include'], true)) {
+            throw new \InvalidArgumentException('FlexDoc Try It credentials must be omit, same-origin, or include.');
         }
     }
 }

--- a/adapters/php/src/FlexDocHost.php
+++ b/adapters/php/src/FlexDocHost.php
@@ -32,12 +32,19 @@ final class FlexDocHost
 
     public function documentation(): FlexDocResponse
     {
+        $tryIt = ['enabled' => $this->config->tryItEnabled];
+        if ($this->config->tryItDefaultServer !== null) $tryIt['defaultServer'] = $this->config->tryItDefaultServer;
+        if ($this->config->tryItCredentials !== null) $tryIt['credentials'] = $this->config->tryItCredentials;
+        if ($this->config->tryItApiClientPersistenceKey !== null) $tryIt['apiClientPersistenceKey'] = $this->config->tryItApiClientPersistenceKey;
+
         $options = [
             'contractVersion' => '1',
             'title' => $this->config->title,
             'theme' => $this->config->theme,
-            'tryIt' => ['enabled' => $this->config->tryItEnabled],
+            'tryIt' => $tryIt,
         ];
+        if ($this->config->expand !== null) $options['expand'] = $this->config->expand;
+
         $title = htmlspecialchars($this->config->title, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
         $path = htmlspecialchars($this->config->path, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
         $specUrl = self::safeJson($this->config->specUrl);

--- a/adapters/php/src/Laravel/FlexDocServiceProvider.php
+++ b/adapters/php/src/Laravel/FlexDocServiceProvider.php
@@ -27,6 +27,10 @@ final class FlexDocServiceProvider extends ServiceProvider
             FILTER_VALIDATE_BOOLEAN,
             FILTER_NULL_ON_FAILURE,
         ) ?? true;
+        $persistenceKey = $config['try_it_api_client_persistence_key'] ?? null;
+        if (is_string($persistenceKey) && strtolower($persistenceKey) === 'false') $persistenceKey = false;
+        $credentials = isset($config['try_it_credentials']) ? trim((string) $config['try_it_credentials']) : null;
+        if ($credentials === '') $credentials = null;
 
         return new FlexDocHost(new FlexDocConfig(
             path: (string) ($config['path'] ?? '/docs'),
@@ -34,6 +38,10 @@ final class FlexDocServiceProvider extends ServiceProvider
             title: (string) ($config['title'] ?? 'API Reference'),
             theme: (string) ($config['theme'] ?? 'system'),
             tryItEnabled: $tryItEnabled,
+            expand: $config['expand'] ?? null,
+            tryItDefaultServer: isset($config['try_it_default_server']) ? (string) $config['try_it_default_server'] : null,
+            tryItCredentials: $credentials,
+            tryItApiClientPersistenceKey: $persistenceKey === false ? false : (isset($persistenceKey) ? (string) $persistenceKey : null),
         ));
     }
 

--- a/adapters/php/tests/run.php
+++ b/adapters/php/tests/run.php
@@ -20,15 +20,47 @@ function check(bool $condition, string $message): void {
     if (!$condition) throw new RuntimeException($message);
 }
 
-$host = new FlexDocHost(new FlexDocConfig('/reference', '/openapi.json', 'PHP <API>'));
+/** @return array<string, mixed> */
+function rendererOptions(string $html): array {
+    $prefix = 'window.__FLEXDOC_OPTIONS__=';
+    $start = strpos($html, $prefix);
+    check($start !== false, 'renderer options start');
+    $start += strlen($prefix);
+    $end = strpos($html, ';</script>', $start);
+    check($end !== false, 'renderer options end');
+    return json_decode(substr($html, $start, $end - $start), true, flags: JSON_THROW_ON_ERROR);
+}
+
+$host = new FlexDocHost(new FlexDocConfig('/reference', '/openapi.json?x=</script>', 'PHP </script><script>alert(1)</script>'));
 $docs = $host->responseForPath('/reference');
 check($docs->status === 200, 'docs status');
-check(str_contains($docs->body, 'PHP &lt;API&gt;'), 'title escaping');
-check(str_contains($docs->body, 'window.__FLEXDOC_SPEC_URL__="/openapi.json"'), 'spec URL');
+check(str_contains($docs->body, 'PHP &lt;/script&gt;&lt;script&gt;alert(1)&lt;/script&gt;'), 'title escaping');
+check(!str_contains($docs->body, '"/openapi.json?x=</script>"'), 'spec JSON escaping');
 check($docs->cacheControl === 'no-cache', 'docs cache');
+$options = rendererOptions($docs->body);
+check(!array_key_exists('expand', $options), 'expand omitted by default');
+check($options['tryIt'] === ['enabled' => true], 'Try It optional fields omitted');
 check($host->rendererJavaScript()->body === file_get_contents(dirname(__DIR__) . '/assets/flexdoc.standalone.js'), 'JS parity');
 check($host->rendererCss()->body === file_get_contents(dirname(__DIR__) . '/assets/flexdoc.standalone.css'), 'CSS parity');
 check($host->responseForPath('/missing')->status === 404, '404 route');
+
+foreach (['documentation', ['parameters', 'tryIt']] as $expand) {
+    $configured = new FlexDocHost(new FlexDocConfig(
+        path: '/configured',
+        specUrl: '/openapi.json',
+        title: 'Configured',
+        expand: $expand,
+        tryItDefaultServer: 'https://gateway.example.test',
+        tryItCredentials: 'include',
+        tryItApiClientPersistenceKey: false,
+    ));
+    $configuredOptions = rendererOptions($configured->documentation()->body);
+    check($configuredOptions['expand'] === $expand, 'expand serialization');
+    check($configuredOptions['tryIt']['enabled'] === true, 'Try It enabled retained');
+    check($configuredOptions['tryIt']['defaultServer'] === 'https://gateway.example.test', 'default server');
+    check($configuredOptions['tryIt']['credentials'] === 'include', 'credentials');
+    check($configuredOptions['tryIt']['apiClientPersistenceKey'] === false, 'persistence false is boolean');
+}
 
 $providerHost = FlexDocServiceProvider::hostFromConfig([
     'path' => '/provider-docs',
@@ -36,8 +68,19 @@ $providerHost = FlexDocServiceProvider::hostFromConfig([
     'title' => 'Provider API',
     'theme' => 'system',
     'try_it_enabled' => 'false',
+    'expand' => ['parameters', 'tryIt'],
+    'try_it_default_server' => 'https://gateway.example.test',
+    'try_it_credentials' => 'same-origin',
+    'try_it_api_client_persistence_key' => 'false',
 ]);
 check($providerHost->config()->tryItEnabled === false, 'Laravel service provider parses string false');
+check($providerHost->config()->expand === ['parameters', 'tryIt'], 'Laravel forwards expansion list');
+check($providerHost->config()->tryItApiClientPersistenceKey === false, 'Laravel forwards persistence false');
+
+$blankCredentialsHost = FlexDocServiceProvider::hostFromConfig([
+    'try_it_credentials' => '   ',
+]);
+check($blankCredentialsHost->config()->tryItCredentials === null, 'Laravel treats blank credentials as unset');
 
 $container = new Container();
 $container->instance(CallableDispatcherContract::class, new CallableDispatcher($container));
@@ -48,7 +91,7 @@ $docsResponse = $router->dispatch(Request::create('/reference', 'GET'));
 $slashResponse = $router->dispatch(Request::create('/reference/', 'GET'));
 check($docsResponse->getStatusCode() === 200, 'Laravel docs route');
 check($slashResponse->getStatusCode() === 200, 'Laravel trailing-slash docs route');
-check(str_contains((string) $slashResponse->getContent(), 'PHP &lt;API&gt;'), 'Laravel trailing-slash docs body');
+check(str_contains((string) $slashResponse->getContent(), 'PHP &lt;/script&gt;'), 'Laravel trailing-slash docs body');
 
 $uris = array_map(static fn ($route) => $route->uri(), $router->getRoutes()->getRoutes());
 check(in_array('reference/__flexdoc/renderer.js', $uris, true), 'Laravel JS route');
@@ -65,4 +108,4 @@ check(
     'Symfony cache header'
 );
 
-echo "PHP FlexDoc host, Laravel config/routes, and Symfony controller passed.\n";
+echo "PHP FlexDoc host, renderer options, Laravel config/routes, and Symfony controller passed.\n";

--- a/adapters/python/README.md
+++ b/adapters/python/README.md
@@ -22,6 +22,8 @@ app.mount('/docs', FlexDocASGI(
 ))
 ```
 
+`FlexDocConfig` and the FastAPI/Flask/Django helpers also accept `expand`, `try_it_default_server`, `try_it_credentials`, and `try_it_api_client_persistence_key`; the persistence key may be a string or `False`, and unset values are omitted from renderer options.
+
 ## Flask / WSGI
 
 ```python

--- a/adapters/python/src/prauga_flexdoc/host.py
+++ b/adapters/python/src/prauga_flexdoc/host.py
@@ -6,6 +6,7 @@ from importlib.resources import files
 from pathlib import Path
 import hashlib
 import json
+from typing import Literal
 
 
 def _safe_json(value: object) -> str:
@@ -26,6 +27,10 @@ class FlexDocConfig:
     title: str = "API Reference"
     theme: str = "system"
     try_it_enabled: bool = True
+    expand: str | list[str] | None = None
+    try_it_default_server: str | None = None
+    try_it_credentials: Literal["omit", "same-origin", "include"] | None = None
+    try_it_api_client_persistence_key: str | Literal[False] | None = None
 
 
 @dataclass(frozen=True)
@@ -74,10 +79,21 @@ class FlexDocHost:
         return files("prauga_flexdoc").joinpath("_assets", name).read_bytes()
 
     def html(self) -> str:
-        options = {
+        try_it: dict[str, object] = {"enabled": self.config.try_it_enabled}
+        if self.config.try_it_default_server is not None:
+            try_it["defaultServer"] = self.config.try_it_default_server
+        if self.config.try_it_credentials is not None:
+            try_it["credentials"] = self.config.try_it_credentials
+        if self.config.try_it_api_client_persistence_key is not None:
+            try_it["apiClientPersistenceKey"] = self.config.try_it_api_client_persistence_key
+
+        options: dict[str, object] = {
             "contractVersion": "1",
             "title": self.config.title,
             "theme": self.config.theme,
-            "tryIt": {"enabled": self.config.try_it_enabled},
+            "tryIt": try_it,
         }
+        if self.config.expand is not None:
+            options["expand"] = self.config.expand
+
         return f'''<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover"><title>{escape(self.config.title)}</title><link rel="stylesheet" href="{self.path}/__flexdoc/renderer.css?v={self.renderer_version}"></head><body><div id="flexdoc-root"></div><script>window.__FLEXDOC_SPEC_URL__={_safe_json(self.config.spec_url)};window.__FLEXDOC_OPTIONS__={_safe_json(options)};</script><script src="{self.path}/__flexdoc/renderer.js?v={self.renderer_version}"></script><script>(async function(){{const root=document.getElementById('flexdoc-root');try{{const baseUri=new URL(window.__FLEXDOC_SPEC_URL__,window.location.href).toString();const response=await fetch(baseUri);if(!response.ok)throw new Error('Unable to load OpenAPI specification: HTTP '+response.status);const spec=await response.json();const config={{spec:spec,options:window.__FLEXDOC_OPTIONS__||{{}},baseUri:baseUri}};if(window.FlexDocStandalone.mountAsync)await window.FlexDocStandalone.mountAsync(root,config);else window.FlexDocStandalone.mount(root,config);}}catch(error){{root.textContent=error instanceof Error?error.message:String(error);}}}})();</script></body></html>'''

--- a/adapters/python/src/prauga_flexdoc/integrations.py
+++ b/adapters/python/src/prauga_flexdoc/integrations.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from typing import Literal
 
 from .asgi import FlexDocASGI
 from .host import FlexDocConfig, FlexDocHost, FlexDocResponse
@@ -10,6 +11,21 @@ def _normalized_path(path: str) -> str:
     return "/" + path.strip("/")
 
 
+def _config_options(
+    *,
+    expand: str | list[str] | None,
+    try_it_default_server: str | None,
+    try_it_credentials: Literal["omit", "same-origin", "include"] | None,
+    try_it_api_client_persistence_key: str | Literal[False] | None,
+) -> dict:
+    return {
+        "expand": expand,
+        "try_it_default_server": try_it_default_server,
+        "try_it_credentials": try_it_credentials,
+        "try_it_api_client_persistence_key": try_it_api_client_persistence_key,
+    }
+
+
 def setup_fastapi_flexdoc(
     app,
     path: str = "/docs",
@@ -17,6 +33,10 @@ def setup_fastapi_flexdoc(
     title: str = "API Reference",
     theme: str = "system",
     try_it_enabled: bool = True,
+    expand: str | list[str] | None = None,
+    try_it_default_server: str | None = None,
+    try_it_credentials: Literal["omit", "same-origin", "include"] | None = None,
+    try_it_api_client_persistence_key: str | Literal[False] | None = None,
 ) -> FlexDocASGI:
     """Mount FlexDoc on FastAPI using the application's generated OpenAPI endpoint."""
     spec_url = getattr(app, "openapi_url", None)
@@ -37,6 +57,12 @@ def setup_fastapi_flexdoc(
         title=title,
         theme=theme,
         try_it_enabled=try_it_enabled,
+        **_config_options(
+            expand=expand,
+            try_it_default_server=try_it_default_server,
+            try_it_credentials=try_it_credentials,
+            try_it_api_client_persistence_key=try_it_api_client_persistence_key,
+        ),
     ))
     app.mount(normalized_path, docs)
     return docs
@@ -50,9 +76,25 @@ def setup_flask_flexdoc(
     title: str = "API Reference",
     theme: str = "system",
     try_it_enabled: bool = True,
+    expand: str | list[str] | None = None,
+    try_it_default_server: str | None = None,
+    try_it_credentials: Literal["omit", "same-origin", "include"] | None = None,
+    try_it_api_client_persistence_key: str | Literal[False] | None = None,
 ) -> FlexDocHost:
     """Register FlexDoc routes on a Flask application without making Flask a hard dependency."""
-    host = FlexDocHost(FlexDocConfig(path, spec_url, title, theme, try_it_enabled))
+    host = FlexDocHost(FlexDocConfig(
+        path=path,
+        spec_url=spec_url,
+        title=title,
+        theme=theme,
+        try_it_enabled=try_it_enabled,
+        **_config_options(
+            expand=expand,
+            try_it_default_server=try_it_default_server,
+            try_it_credentials=try_it_credentials,
+            try_it_api_client_persistence_key=try_it_api_client_persistence_key,
+        ),
+    ))
     normalized = host.path
     endpoint_prefix = "flexdoc_" + re.sub(r"[^a-zA-Z0-9_]", "_", normalized).strip("_")
 
@@ -75,6 +117,10 @@ def django_urlpatterns(
     title: str = "API Reference",
     theme: str = "system",
     try_it_enabled: bool = True,
+    expand: str | list[str] | None = None,
+    try_it_default_server: str | None = None,
+    try_it_credentials: Literal["omit", "same-origin", "include"] | None = None,
+    try_it_api_client_persistence_key: str | Literal[False] | None = None,
 ):
     """Return Django URL patterns for FlexDoc. Django is imported lazily and remains optional."""
     try:
@@ -83,7 +129,19 @@ def django_urlpatterns(
     except ImportError as error:
         raise RuntimeError("Django is required to use django_urlpatterns(); install prauga-flexdoc[django]") from error
 
-    host = FlexDocHost(FlexDocConfig(path, spec_url, title, theme, try_it_enabled))
+    host = FlexDocHost(FlexDocConfig(
+        path=path,
+        spec_url=spec_url,
+        title=title,
+        theme=theme,
+        try_it_enabled=try_it_enabled,
+        **_config_options(
+            expand=expand,
+            try_it_default_server=try_it_default_server,
+            try_it_credentials=try_it_credentials,
+            try_it_api_client_persistence_key=try_it_api_client_persistence_key,
+        ),
+    ))
     route = host.path.strip("/")
 
     def to_django(request, request_path: str):

--- a/adapters/python/tests/test_asgi.py
+++ b/adapters/python/tests/test_asgi.py
@@ -1,10 +1,12 @@
 import asyncio
+import json
 import unittest
 from pathlib import Path
 import sys
 
 sys.path.insert(0, str(Path(__file__).parents[1] / "src"))
 from prauga_flexdoc import FlexDocASGI, FlexDocConfig
+
 
 async def request(app, path):
     messages = []
@@ -13,18 +15,56 @@ async def request(app, path):
     await app({"type":"http", "path":path, "method":"GET"}, receive, send)
     return messages
 
+
+def options_from_html(body: str):
+    prefix = "window.__FLEXDOC_OPTIONS__="
+    start = body.index(prefix) + len(prefix)
+    end = body.index(";</script>", start)
+    return json.loads(body[start:end])
+
+
 class FlexDocASGITest(unittest.TestCase):
     def test_page_and_bundled_assets(self):
-        app = FlexDocASGI(FlexDocConfig(path="/reference", title="</script><script>alert(1)</script>"))
+        app = FlexDocASGI(FlexDocConfig(path="/reference", spec_url="/openapi.json?x=</script>", title="</script><script>alert(1)</script>"))
         messages = asyncio.run(request(app, "/reference"))
         body = messages[-1]["body"].decode()
         self.assertEqual(messages[0]["status"], 200)
         self.assertIn("/reference/__flexdoc/renderer.js?v=", body)
         self.assertIn("/reference/__flexdoc/renderer.css?v=", body)
         self.assertNotIn("</script><script>alert(1)</script>", body)
+        self.assertNotIn('"/openapi.json?x=</script>"', body)
         messages = asyncio.run(request(app, "/reference/__flexdoc/renderer.js"))
         self.assertEqual(messages[0]["status"], 200)
         self.assertGreater(len(messages[-1]["body"]), 0)
         self.assertTrue(any(name == b"cache-control" and b"immutable" in value for name, value in messages[0]["headers"]))
+
+    def test_optional_renderer_fields_are_omitted(self):
+        app = FlexDocASGI(FlexDocConfig(path="/reference", try_it_enabled=True))
+        messages = asyncio.run(request(app, "/reference"))
+        options = options_from_html(messages[-1]["body"].decode())
+        self.assertNotIn("expand", options)
+        self.assertEqual(options["tryIt"], {"enabled": True})
+
+    def test_renderer_options_support_preset_and_section_list(self):
+        for expand in ("documentation", ["parameters", "tryIt"]):
+            with self.subTest(expand=expand):
+                app = FlexDocASGI(FlexDocConfig(
+                    path="/reference",
+                    expand=expand,
+                    try_it_enabled=True,
+                    try_it_default_server="https://gateway.example.test",
+                    try_it_credentials="include",
+                    try_it_api_client_persistence_key=False,
+                ))
+                messages = asyncio.run(request(app, "/reference"))
+                options = options_from_html(messages[-1]["body"].decode())
+                self.assertEqual(options["expand"], expand)
+                self.assertEqual(options["tryIt"], {
+                    "enabled": True,
+                    "defaultServer": "https://gateway.example.test",
+                    "credentials": "include",
+                    "apiClientPersistenceKey": False,
+                })
+
 
 if __name__ == "__main__": unittest.main()

--- a/adapters/ruby/README.md
+++ b/adapters/ruby/README.md
@@ -18,6 +18,8 @@ host = Prauga::FlexDoc::Host.new(
 run Prauga::FlexDoc::RackApp.new(host)
 ```
 
+`Prauga::FlexDoc::Config` also accepts `expand`, `try_it_default_server`, `try_it_credentials`, and `try_it_api_client_persistence_key`; `expand` may be a preset string or section array, and persistence may be a string or `false`.
+
 The Rack app reconstructs `SCRIPT_NAME + PATH_INFO`, so it also works correctly when mounted beneath another Rack application.
 
 ## Rails

--- a/adapters/ruby/lib/prauga/flexdoc/config.rb
+++ b/adapters/ruby/lib/prauga/flexdoc/config.rb
@@ -2,13 +2,49 @@
 
 module Prauga
   module FlexDoc
-    Config = Data.define(:path, :spec_url, :title, :theme, :try_it_enabled) do
-      def initialize(path: "/docs", spec_url: "/openapi.json", title: "API Reference", theme: "system", try_it_enabled: true)
+    Config = Data.define(
+      :path,
+      :spec_url,
+      :title,
+      :theme,
+      :try_it_enabled,
+      :expand,
+      :try_it_default_server,
+      :try_it_credentials,
+      :try_it_api_client_persistence_key
+    ) do
+      def initialize(
+        path: "/docs",
+        spec_url: "/openapi.json",
+        title: "API Reference",
+        theme: "system",
+        try_it_enabled: true,
+        expand: nil,
+        try_it_default_server: nil,
+        try_it_credentials: nil,
+        try_it_api_client_persistence_key: nil
+      )
         normalized = "/#{path.to_s.gsub(%r{\A/+|/+$}, "")}"
         normalized = "/docs" if normalized == "/"
         raise ArgumentError, "FlexDoc theme must be system, light, or dark" unless %w[system light dark].include?(theme)
+        if try_it_credentials && !%w[omit same-origin include].include?(try_it_credentials)
+          raise ArgumentError, "FlexDoc Try It credentials must be omit, same-origin, or include"
+        end
+        unless try_it_api_client_persistence_key.nil? || try_it_api_client_persistence_key == false || try_it_api_client_persistence_key.is_a?(String)
+          raise ArgumentError, "FlexDoc API Client persistence key must be a string, false, or nil"
+        end
 
-        super(path: normalized, spec_url:, title:, theme:, try_it_enabled: !!try_it_enabled)
+        super(
+          path: normalized,
+          spec_url: spec_url,
+          title: title,
+          theme: theme,
+          try_it_enabled: !!try_it_enabled,
+          expand: expand,
+          try_it_default_server: try_it_default_server,
+          try_it_credentials: try_it_credentials,
+          try_it_api_client_persistence_key: try_it_api_client_persistence_key
+        )
       end
     end
   end

--- a/adapters/ruby/lib/prauga/flexdoc/host.rb
+++ b/adapters/ruby/lib/prauga/flexdoc/host.rb
@@ -28,12 +28,18 @@ module Prauga
       end
 
       def documentation
+        try_it = { enabled: config.try_it_enabled }
+        try_it[:defaultServer] = config.try_it_default_server unless config.try_it_default_server.nil?
+        try_it[:credentials] = config.try_it_credentials unless config.try_it_credentials.nil?
+        try_it[:apiClientPersistenceKey] = config.try_it_api_client_persistence_key unless config.try_it_api_client_persistence_key.nil?
+
         options = {
           contractVersion: "1",
           title: config.title,
           theme: config.theme,
-          tryIt: { enabled: config.try_it_enabled }
+          tryIt: try_it
         }
+        options[:expand] = config.expand unless config.expand.nil?
         title = CGI.escapeHTML(config.title.to_s)
         path = CGI.escapeHTML(config.path)
         spec_url = safe_json(config.spec_url)

--- a/adapters/ruby/test/test_host.rb
+++ b/adapters/ruby/test/test_host.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "json"
 require "minitest/autorun"
 require "rack/mock"
 require "action_dispatch"
@@ -12,6 +13,12 @@ class FlexDocHostTest < Minitest::Test
     )
   end
 
+  def renderer_options(host)
+    body = host.response_for_path(host.config.path).body
+    json = body.match(/window\.__FLEXDOC_OPTIONS__=(.*?);<\/script>/)[1]
+    JSON.parse(json)
+  end
+
   def test_host_serves_docs_and_assets
     docs = @host.response_for_path("/reference")
     assert_equal 200, docs.status
@@ -19,10 +26,51 @@ class FlexDocHostTest < Minitest::Test
     assert_includes docs.body, "Ruby &lt;API&gt;"
     assert_includes docs.body, 'window.__FLEXDOC_SPEC_URL__="/openapi.json"'
 
+    options = renderer_options(@host)
+    assert_equal true, options.dig("tryIt", "enabled")
+    refute options.key?("expand")
+
     js = @host.renderer_javascript
     assert_equal 200, js.status
     assert_includes js.cache_control, "immutable"
     assert_operator js.body.bytesize, :>, 1000
+  end
+
+  def test_renderer_settings_use_renderer_shape
+    host = Prauga::FlexDoc::Host.new(
+      Prauga::FlexDoc::Config.new(
+        expand: "documentation",
+        try_it_default_server: "https://api.example.test",
+        try_it_credentials: "include",
+        try_it_api_client_persistence_key: false
+      )
+    )
+    options = renderer_options(host)
+
+    assert_equal "documentation", options["expand"]
+    assert_equal true, options.dig("tryIt", "enabled")
+    assert_equal "https://api.example.test", options.dig("tryIt", "defaultServer")
+    assert_equal "include", options.dig("tryIt", "credentials")
+    assert_equal false, options.dig("tryIt", "apiClientPersistenceKey")
+
+    list_host = Prauga::FlexDoc::Host.new(
+      Prauga::FlexDoc::Config.new(expand: ["parameters", "tryIt"])
+    )
+    assert_equal ["parameters", "tryIt"], renderer_options(list_host)["expand"]
+  end
+
+  def test_renderer_json_remains_script_safe
+    host = Prauga::FlexDoc::Host.new(
+      Prauga::FlexDoc::Config.new(
+        spec_url: "</script><script>alert('spec')</script>",
+        title: "</script><script>alert('title')</script>"
+      )
+    )
+    body = host.response_for_path("/docs").body
+
+    refute_includes body, "</script><script>alert('spec')</script>"
+    refute_includes body, "</script><script>alert('title')</script>"
+    assert_includes body, "\\u003c/script\\u003e"
   end
 
   def test_rack_app_preserves_mount_prefix

--- a/adapters/rust-actix/README.md
+++ b/adapters/rust-actix/README.md
@@ -14,4 +14,6 @@ HttpServer::new(|| App::new().service(scope(Config {
 })))
 ```
 
+`Config` also accepts `expand`, `try_it_default_server`, `try_it_credentials`, and `try_it_api_client_persistence_key`. Flexible renderer values use `serde_json::Value`, so expansion can be a preset string or section array and persistence can be a string or JSON `false`.
+
 The crate packages renderer JS/CSS locally and serves fingerprinted immutable asset URLs. No CDN or Actix-specific renderer implementation is used.

--- a/adapters/rust-actix/src/lib.rs
+++ b/adapters/rust-actix/src/lib.rs
@@ -1,5 +1,5 @@
 use actix_web::{http::header, web, HttpResponse, Scope};
-use serde_json::json;
+use serde_json::{json, Value};
 
 static RENDERER_JS: &[u8] = include_bytes!("../assets/flexdoc.standalone.js");
 static RENDERER_CSS: &[u8] = include_bytes!("../assets/flexdoc.standalone.css");
@@ -11,6 +11,10 @@ pub struct Config {
     pub title: String,
     pub theme: String,
     pub try_it_enabled: bool,
+    pub expand: Option<Value>,
+    pub try_it_default_server: Option<String>,
+    pub try_it_credentials: Option<String>,
+    pub try_it_api_client_persistence_key: Option<Value>,
 }
 
 impl Default for Config {
@@ -21,6 +25,10 @@ impl Default for Config {
             title: "API Reference".into(),
             theme: "system".into(),
             try_it_enabled: true,
+            expand: None,
+            try_it_default_server: None,
+            try_it_credentials: None,
+            try_it_api_client_persistence_key: None,
         }
     }
 }
@@ -81,13 +89,34 @@ fn escape_html(value: &str) -> String {
         .replace('\'', "&#39;")
 }
 
-fn render_html(cfg: &Config) -> String {
-    let options = json!({
+fn renderer_options(cfg: &Config) -> Value {
+    let mut options = json!({
         "contractVersion": "1",
         "title": cfg.title,
         "theme": cfg.theme,
         "tryIt": {"enabled": cfg.try_it_enabled}
     });
+
+    if let Some(expand) = &cfg.expand {
+        options["expand"] = expand.clone();
+    }
+
+    let try_it = options["tryIt"].as_object_mut().expect("Try It options are an object");
+    if let Some(default_server) = &cfg.try_it_default_server {
+        try_it.insert("defaultServer".into(), json!(default_server));
+    }
+    if let Some(credentials) = &cfg.try_it_credentials {
+        try_it.insert("credentials".into(), json!(credentials));
+    }
+    if let Some(persistence_key) = &cfg.try_it_api_client_persistence_key {
+        try_it.insert("apiClientPersistenceKey".into(), persistence_key.clone());
+    }
+
+    options
+}
+
+fn render_html(cfg: &Config) -> String {
+    let options = renderer_options(cfg);
     let version = renderer_version();
     format!(r#"<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover"><title>{}</title><link rel="stylesheet" href="{}/__flexdoc/renderer.css?v={}"></head><body><div id="flexdoc-root"></div><script>window.__FLEXDOC_SPEC_URL__={};window.__FLEXDOC_OPTIONS__={};</script><script src="{}/__flexdoc/renderer.js?v={}"></script><script>(async function(){{const root=document.getElementById('flexdoc-root');try{{const baseUri=new URL(window.__FLEXDOC_SPEC_URL__,window.location.href).toString();const response=await fetch(baseUri);if(!response.ok)throw new Error('Unable to load OpenAPI specification: HTTP '+response.status);const spec=await response.json();const config={{spec:spec,options:window.__FLEXDOC_OPTIONS__||{{}},baseUri:baseUri}};if(window.FlexDocStandalone.mountAsync)await window.FlexDocStandalone.mountAsync(root,config);else window.FlexDocStandalone.mount(root,config);}}catch(error){{root.textContent=error instanceof Error?error.message:String(error);}}}})();</script></body></html>"#,
         escape_html(&cfg.title), cfg.path, version, safe_json(json!(cfg.spec_url)), safe_json(options), cfg.path, version)
@@ -99,10 +128,36 @@ mod tests {
     use actix_web::{test, App};
 
     #[actix_rt::test]
+    async fn renderer_settings_are_omitted_until_configured() {
+        let default_options = renderer_options(&Config::default());
+        assert_eq!(default_options["tryIt"]["enabled"], true);
+        assert!(default_options.get("expand").is_none());
+        assert!(default_options["tryIt"].get("defaultServer").is_none());
+
+        let configured = Config {
+            expand: Some(json!("documentation")),
+            try_it_default_server: Some("https://api.example.test".into()),
+            try_it_credentials: Some("include".into()),
+            try_it_api_client_persistence_key: Some(json!(false)),
+            ..Default::default()
+        };
+        let options = renderer_options(&configured);
+        assert_eq!(options["expand"], "documentation");
+        assert_eq!(options["tryIt"]["enabled"], true);
+        assert_eq!(options["tryIt"]["defaultServer"], "https://api.example.test");
+        assert_eq!(options["tryIt"]["credentials"], "include");
+        assert_eq!(options["tryIt"]["apiClientPersistenceKey"], false);
+
+        let list_options = renderer_options(&Config { expand: Some(json!(["parameters", "tryIt"])), ..Default::default() });
+        assert_eq!(list_options["expand"], json!(["parameters", "tryIt"]));
+    }
+
+    #[actix_rt::test]
     async fn serves_docs_and_canonical_assets() {
         let app = test::init_service(App::new().service(scope(Config {
             path: "/reference".into(),
-            title: "Actix <API>".into(),
+            spec_url: "</script><script>alert(2)</script>".into(),
+            title: "Actix </script><script>alert(1)</script>".into(),
             ..Default::default()
         }))).await;
 
@@ -110,7 +165,9 @@ mod tests {
         assert!(docs.status().is_success());
         let docs_body = test::read_body(docs).await;
         let docs_text = String::from_utf8(docs_body.to_vec()).unwrap();
-        assert!(docs_text.contains("Actix &lt;API&gt;"));
+        assert!(!docs_text.contains("</script><script>alert(1)</script>"));
+        assert!(!docs_text.contains("</script><script>alert(2)</script>"));
+        assert!(docs_text.contains("\\u003c/script\\u003e"));
         assert!(docs_text.contains("/reference/__flexdoc/renderer.js?v="));
 
         let js = test::call_service(&app, test::TestRequest::get().uri("/reference/__flexdoc/renderer.js").to_request()).await;

--- a/adapters/rust/README.md
+++ b/adapters/rust/README.md
@@ -12,6 +12,8 @@ let app = prauga_flexdoc_axum::router(prauga_flexdoc_axum::Config {
 });
 ```
 
+`Config` also accepts `expand`, `try_it_default_server`, `try_it_credentials`, and `try_it_api_client_persistence_key`. The flexible renderer values use `serde_json::Value`, so `expand` can be a preset string or section array and persistence can be a string or JSON `false`.
+
 For code-first APIs using `utoipa`, pass the generated document directly:
 
 ```rust

--- a/adapters/rust/src/lib.rs
+++ b/adapters/rust/src/lib.rs
@@ -13,10 +13,26 @@ pub struct Config {
     pub title: String,
     pub theme: String,
     pub try_it_enabled: bool,
+    pub expand: Option<Value>,
+    pub try_it_default_server: Option<String>,
+    pub try_it_credentials: Option<String>,
+    pub try_it_api_client_persistence_key: Option<Value>,
 }
 
 impl Default for Config {
-    fn default() -> Self { Self { path:"/docs".into(), spec_url:"/openapi.json".into(), title:"API Reference".into(), theme:"system".into(), try_it_enabled:true } }
+    fn default() -> Self {
+        Self {
+            path:"/docs".into(),
+            spec_url:"/openapi.json".into(),
+            title:"API Reference".into(),
+            theme:"system".into(),
+            try_it_enabled:true,
+            expand: None,
+            try_it_default_server: None,
+            try_it_credentials: None,
+            try_it_api_client_persistence_key: None,
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -86,8 +102,34 @@ fn renderer_version() -> String {
     format!("{hash:016x}")
 }
 
+fn renderer_options(cfg: &Config) -> Value {
+    let mut options = json!({
+        "contractVersion":"1",
+        "title":cfg.title,
+        "theme":cfg.theme,
+        "tryIt":{"enabled":cfg.try_it_enabled}
+    });
+
+    if let Some(expand) = &cfg.expand {
+        options["expand"] = expand.clone();
+    }
+
+    let try_it = options["tryIt"].as_object_mut().expect("Try It options are an object");
+    if let Some(default_server) = &cfg.try_it_default_server {
+        try_it.insert("defaultServer".into(), json!(default_server));
+    }
+    if let Some(credentials) = &cfg.try_it_credentials {
+        try_it.insert("credentials".into(), json!(credentials));
+    }
+    if let Some(persistence_key) = &cfg.try_it_api_client_persistence_key {
+        try_it.insert("apiClientPersistenceKey".into(), persistence_key.clone());
+    }
+
+    options
+}
+
 fn render_html(cfg: &Config) -> String {
-    let options = json!({"contractVersion":"1","title":cfg.title,"theme":cfg.theme,"tryIt":{"enabled":cfg.try_it_enabled}});
+    let options = renderer_options(cfg);
     let version = renderer_version();
     format!(r#"<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover"><title>{}</title><link rel="stylesheet" href="{}/__flexdoc/renderer.css?v={}"></head><body><div id="flexdoc-root"></div><script>window.__FLEXDOC_SPEC_URL__={};window.__FLEXDOC_OPTIONS__={};</script><script src="{}/__flexdoc/renderer.js?v={}"></script><script>(async function(){{const root=document.getElementById('flexdoc-root');try{{const baseUri=new URL(window.__FLEXDOC_SPEC_URL__,window.location.href).toString();const response=await fetch(baseUri);if(!response.ok)throw new Error('Unable to load OpenAPI specification: HTTP '+response.status);const spec=await response.json();const config={{spec:spec,options:window.__FLEXDOC_OPTIONS__||{{}},baseUri:baseUri}};if(window.FlexDocStandalone.mountAsync)await window.FlexDocStandalone.mountAsync(root,config);else window.FlexDocStandalone.mount(root,config);}}catch(error){{root.textContent=error instanceof Error?error.message:String(error);}}}})();</script></body></html>"#, escape_html(&cfg.title), cfg.path, version, safe_json(json!(cfg.spec_url)), safe_json(options), cfg.path, version)
 }
@@ -100,13 +142,40 @@ mod tests {
 
     #[test]
     fn html_is_script_safe_and_assets_are_embedded() {
-        let cfg = Config { title:"</script><script>alert(1)</script>".into(), path:"/docs".into(), ..Default::default() };
+        let cfg = Config { title:"</script><script>alert(1)</script>".into(), spec_url:"</script><script>alert(2)</script>".into(), path:"/docs".into(), ..Default::default() };
         let body = render_html(&cfg);
         assert!(!body.contains("</script><script>alert(1)</script>"));
+        assert!(!body.contains("</script><script>alert(2)</script>"));
+        assert!(body.contains("\\u003c/script\\u003e"));
         assert!(body.contains("/docs/__flexdoc/renderer.js?v="));
         assert!(body.contains("/docs/__flexdoc/renderer.css?v="));
         assert!(!RENDERER_JS.is_empty());
         assert!(!RENDERER_CSS.is_empty());
+    }
+
+    #[test]
+    fn renderer_settings_are_omitted_until_configured() {
+        let default_options = renderer_options(&Config::default());
+        assert_eq!(default_options["tryIt"]["enabled"], true);
+        assert!(default_options.get("expand").is_none());
+        assert!(default_options["tryIt"].get("defaultServer").is_none());
+
+        let configured = Config {
+            expand: Some(json!("documentation")),
+            try_it_default_server: Some("https://api.example.test".into()),
+            try_it_credentials: Some("include".into()),
+            try_it_api_client_persistence_key: Some(json!(false)),
+            ..Default::default()
+        };
+        let options = renderer_options(&configured);
+        assert_eq!(options["expand"], "documentation");
+        assert_eq!(options["tryIt"]["enabled"], true);
+        assert_eq!(options["tryIt"]["defaultServer"], "https://api.example.test");
+        assert_eq!(options["tryIt"]["credentials"], "include");
+        assert_eq!(options["tryIt"]["apiClientPersistenceKey"], false);
+
+        let list_options = renderer_options(&Config { expand: Some(json!(["parameters", "tryIt"])), ..Default::default() });
+        assert_eq!(list_options["expand"], json!(["parameters", "tryIt"]));
     }
 
     #[tokio::test]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,7 +50,7 @@ setupFlexDoc(app, {
 | `version`                  | `string`                     | `"1.0.0"`                         | The version of your API                                                  |
 | `theme`                    | `object`                     | See [Theming Guide](./theming.md) | Custom theme options                                                     |
 | `hideHostname`             | `boolean`                    | `false`                           | Whether to hide the hostname in the API endpoints                        |
-| `expand`                   | `string | string[]`          | `minimal`                         | Default expanded endpoint sections; accepts presets or explicit sections |
+| `expand`                   | `string | string[]`          | omitted (compact)                 | Default expanded endpoint sections; accepts presets or explicit sections |
 | `pathInMiddlePanel`        | `boolean`                    | `false`                           | Whether to show the path in the middle panel instead of the left sidebar |
 | `defaultModelsExpandDepth` | `number`                     | `1`                               | The default expand depth for models                                      |
 | `defaultModelExpandDepth`  | `number`                     | `1`                               | The default expand depth for model properties                            |
@@ -67,7 +67,6 @@ setupFlexDoc(app, {
 | `favicon`                  | `string`                     | `null`                            | The URL to a custom favicon                                              |
 | `auth`                     | `object`                     | `null`                            | Authentication configuration (see below)                                 |
 
-
 ## Expansion Defaults and Viewer Preferences
 
 FlexDoc keeps endpoint pages compact by default. Hosts can set the initial expansion baseline with `expand`:
@@ -83,7 +82,22 @@ options: {
 
 Supported presets are `minimal`, `documentation`, `interactive`, `all`, and `none`. Explicit section names are `parameters`, `requestBody`, `responses`, `tryIt`, and `codeSamples`. `expandResponses` remains accepted for backwards compatibility when `expand` is not supplied, but new integrations should use `expand`.
 
-The host value is a default rather than a policy. Readers can open **Settings** in the FlexDoc top bar and choose their own expansion baseline. That preference is stored locally per documentation origin and API title and takes precedence over the host default. **Reset to documentation defaults** removes the viewer override. Individual section clicks are transient and are not persisted.
+The host value is a default rather than a policy. Readers can open **Settings** and choose their own expansion baseline. When the top bar is hidden in an embed, FlexDoc provides a floating Settings entry point. The preference is stored locally per documentation origin and API title and takes precedence over the host default. **Reset to documentation defaults** removes the viewer override. Individual section clicks are transient and are not persisted.
+
+## Language Adapter Renderer Options
+
+The self-hosted Go, Python, PHP, Ruby, Elixir, Rust (Axum and Actix), .NET, and Java adapters expose the same renderer settings as the JavaScript host. Existing first-class adapter fields such as `path`, `specUrl`, `title`, `theme`, and `tryIt.enabled` remain authoritative. The following additional values are injected into `window.__FLEXDOC_OPTIONS__` only when the host supplies them:
+
+| Renderer field | Type | Omitted behavior |
+| --- | --- | --- |
+| `expand` | preset string or section list | compact renderer default |
+| `tryIt.defaultServer` | string | renderer chooses the operation/spec server |
+| `tryIt.credentials` | `omit`, `same-origin`, or `include` | renderer fetch default |
+| `tryIt.apiClientPersistenceKey` | string or `false` | renderer derives its normal workspace key; `false` disables IndexedDB workspace persistence |
+
+For typed languages, adapter APIs use the closest native representation. Java Spring additionally exposes `expand-sections`; when both `expand` and `expand-sections` are configured, the section list wins. All language hosts preserve JSON types, so `apiClientPersistenceKey: false` is emitted as JSON `false`, never the string `"false"`.
+
+The JavaScript backend integrations (Express, Fastify, NestJS, and Hono) already pass the complete `options` object through and therefore do not need a separate adapter mapping for these fields.
 
 ## Authentication Options
 
@@ -123,7 +137,7 @@ options: {
   requestInterceptor: (req) => {
     req.headers['X-Custom-Header'] = 'value';
     return req;
-  };
+  },
 }
 ```
 
@@ -134,7 +148,7 @@ options: {
   responseInterceptor: (res) => {
     console.log(res);
     return res;
-  };
+  },
 }
 ```
 

--- a/packages/renderer-contract/flexdoc-renderer.schema.json
+++ b/packages/renderer-contract/flexdoc-renderer.schema.json
@@ -29,7 +29,7 @@
         "showRequestHeaders": { "type": "boolean" },
         "requiredPropsFirst": { "type": "boolean" },
         "sortPropsAlphabetically": { "type": "boolean" },
-        "tryIt": { "type": "object", "properties": { "enabled": { "type": "boolean" }, "defaultServer": { "type": "string" }, "credentials": { "enum": ["omit", "same-origin", "include"] } } },
+        "tryIt": { "type": "object", "properties": { "enabled": { "type": "boolean" }, "defaultServer": { "type": "string" }, "credentials": { "enum": ["omit", "same-origin", "include"] }, "apiClientPersistenceKey": { "oneOf": [{ "type": "string" }, { "const": false }] } } },
         "codeSamples": { "type": "object", "properties": { "enabled": { "type": "boolean" }, "languages": { "type": "array", "items": { "enum": ["curl", "javascript", "python", "go", "java"] } } } },
         "footer": { "type": "object" }
       }


### PR DESCRIPTION
## Summary

- expose renderer `expand` on every self-hosted language adapter while preserving compact behavior when omitted
- expose `tryIt.defaultServer`, `tryIt.credentials`, and `tryIt.apiClientPersistenceKey` under the existing `tryIt` object
- keep existing first-class `path`, spec URL, title, theme, and Try It enabled settings authoritative
- preserve JSON types, including `apiClientPersistenceKey: false`
- add preset and explicit-section expansion coverage across adapter families
- keep JavaScript backend integrations as passthroughs rather than duplicating adapter mapping
- add the missing renderer-contract schema entry for `tryIt.apiClientPersistenceKey`
- replace JVM hand-concatenated options JSON with structural map/list serialization
- wire Spring properties into the shared JVM host, with `expand-sections` taking precedence over scalar `expand`
- add decoded .NET renderer-option contract coverage and run it in the adapter workflow
- treat blank Laravel Try It credentials as unset instead of failing config validation
- document the new settings in every language adapter README and `docs/configuration.md`

## Stack

Stacked directly on **#52**.

## Validation

Final exact head `0e552908ffb515f77ce37e080cc61649617d21c4` is one commit on #52 and passes:

- CI
- Browser E2E
- Framework Coverage Completion
- Java Adapters
- Python Adapters
- PHP Adapters
- Ruby Adapters
- .NET Adapter

The framework lane covers Hono, Go router examples, Actix, Ktor, and Elixir/Plug; adapter renderer parity is green.