### PR TITLE
Refresh examples against published 2.8 package versions

### DIFF
--- a/examples/go-chi/go.sum
+++ b/examples/go-chi/go.sum
@@ -1,4 +1,4 @@
-github.com/prauga/flexdoc/adapters/go v0.4.0 h1:lTqHzWV+HR8gDSvnq5tko8dft+qRNsWvkVDogW3vM3s=
+github.com/prauga/flexdoc/adapters/go v0.4.0 h1:hknffYWkZAxrNGNCLKaYZvDMuzw1WELr1P6S3XSOl6k=
 github.com/prauga/flexdoc/adapters/go v0.4.0/go.mod h1:tMdyVXq3OY5uhengBClaE9XC0/fD/BuMIx2GUcDMi9k=
 github.com/go-chi/chi/v5 v5.3.2 h1:5YQkICvTCSZ25hoRsyJazN0scjzKGiu4VAUc7H1o1nY=
 github.com/go-chi/chi/v5 v5.3.2/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=

--- a/examples/go-echo/go.sum
+++ b/examples/go-echo/go.sum
@@ -1,4 +1,4 @@
-github.com/prauga/flexdoc/adapters/go v0.4.0 h1:lTqHzWV+HR8gDSvnq5tko8dft+qRNsWvkVDogW3vM3s=
+github.com/prauga/flexdoc/adapters/go v0.4.0 h1:hknffYWkZAxrNGNCLKaYZvDMuzw1WELr1P6S3XSOl6k=
 github.com/prauga/flexdoc/adapters/go v0.4.0/go.mod h1:tMdyVXq3OY5uhengBClaE9XC0/fD/BuMIx2GUcDMi9k=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/examples/go-fiber/go.sum
+++ b/examples/go-fiber/go.sum
@@ -1,4 +1,4 @@
-github.com/prauga/flexdoc/adapters/go v0.4.0 h1:lTqHzWV+HR8gDSvnq5tko8dft+qRNsWvkVDogW3vM3s=
+github.com/prauga/flexdoc/adapters/go v0.4.0 h1:hknffYWkZAxrNGNCLKaYZvDMuzw1WELr1P6S3XSOl6k=
 github.com/prauga/flexdoc/adapters/go v0.4.0/go.mod h1:tMdyVXq3OY5uhengBClaE9XC0/fD/BuMIx2GUcDMi9k=
 github.com/andybalholm/brotli v1.2.2 h1:HzTuoo2ErYQqf5qvcJInB8uvqSVxRttzkFexPWtnceM=
 github.com/andybalholm/brotli v1.2.2/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=

--- a/examples/go-gin/go.sum
+++ b/examples/go-gin/go.sum
@@ -1,4 +1,4 @@
-github.com/prauga/flexdoc/adapters/go v0.4.0 h1:lTqHzWV+HR8gDSvnq5tko8dft+qRNsWvkVDogW3vM3s=
+github.com/prauga/flexdoc/adapters/go v0.4.0 h1:hknffYWkZAxrNGNCLKaYZvDMuzw1WELr1P6S3XSOl6k=
 github.com/prauga/flexdoc/adapters/go v0.4.0/go.mod h1:tMdyVXq3OY5uhengBClaE9XC0/fD/BuMIx2GUcDMi9k=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=

--- a/examples/go-net-http/go.sum
+++ b/examples/go-net-http/go.sum
@@ -1,2 +1,2 @@
-github.com/prauga/flexdoc/adapters/go v0.4.0 h1:lTqHzWV+HR8gDSvnq5tko8dft+qRNsWvkVDogW3vM3s=
+github.com/prauga/flexdoc/adapters/go v0.4.0 h1:hknffYWkZAxrNGNCLKaYZvDMuzw1WELr1P6S3XSOl6k=
 github.com/prauga/flexdoc/adapters/go v0.4.0/go.mod h1:tMdyVXq3OY5uhengBClaE9XC0/fD/BuMIx2GUcDMi9k=

--- a/examples/javascript-express/package-lock.json
+++ b/examples/javascript-express/package-lock.json
@@ -8,14 +8,14 @@
       "name": "flexdoc-example-express",
       "version": "0.1.0",
       "dependencies": {
-        "@prauga/flexdoc-backend": "2.3.0",
+        "@prauga/flexdoc-backend": "2.8.0",
         "express": "^5.1.0"
       }
     },
     "node_modules/@prauga/flexdoc-backend": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@prauga/flexdoc-backend/-/flexdoc-backend-2.3.0.tgz",
-      "integrity": "sha512-p/jEpU6nSc3WlGUnO8wCInm+krVPsKGYlbN6L6OhA01iCYkPHtqVOwaycHwVtKQFDtnBRHkdY43m6c0XU6CCOQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@prauga/flexdoc-backend/-/flexdoc-backend-2.8.0.tgz",
+      "integrity": "sha512-+71V0Vbu1ozkeC374C55AXNoks/CeDSfxkakPfvi7rjuwoIQcjVIBvk37/eUZSkXcWEP0xWkFFaJwbFJj5nfog==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "jsonwebtoken": "^9.0.2",

--- a/examples/javascript-fastify/package-lock.json
+++ b/examples/javascript-fastify/package-lock.json
@@ -8,7 +8,7 @@
       "name": "flexdoc-example-fastify",
       "version": "0.1.0",
       "dependencies": {
-        "@prauga/flexdoc-backend": "2.3.0",
+        "@prauga/flexdoc-backend": "2.8.0",
         "fastify": "^5.5.0"
       }
     },
@@ -130,9 +130,9 @@
       "license": "MIT"
     },
     "node_modules/@prauga/flexdoc-backend": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@prauga/flexdoc-backend/-/flexdoc-backend-2.3.0.tgz",
-      "integrity": "sha512-p/jEpU6nSc3WlGUnO8wCInm+krVPsKGYlbN6L6OhA01iCYkPHtqVOwaycHwVtKQFDtnBRHkdY43m6c0XU6CCOQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@prauga/flexdoc-backend/-/flexdoc-backend-2.8.0.tgz",
+      "integrity": "sha512-+71V0Vbu1ozkeC374C55AXNoks/CeDSfxkakPfvi7rjuwoIQcjVIBvk37/eUZSkXcWEP0xWkFFaJwbFJj5nfog==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "jsonwebtoken": "^9.0.2",

--- a/examples/javascript-hono/package-lock.json
+++ b/examples/javascript-hono/package-lock.json
@@ -9,14 +9,14 @@
       "version": "0.1.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@prauga/flexdoc-backend": "2.3.0",
+        "@prauga/flexdoc-backend": "2.8.0",
         "hono": "^4.13.5"
       }
     },
     "node_modules/@prauga/flexdoc-backend": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@prauga/flexdoc-backend/-/flexdoc-backend-2.3.0.tgz",
-      "integrity": "sha512-p/jEpU6nSc3WlGUnO8wCInm+krVPsKGYlbN6L6OhA01iCYkPHtqVOwaycHwVtKQFDtnBRHkdY43m6c0XU6CCOQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@prauga/flexdoc-backend/-/flexdoc-backend-2.8.0.tgz",
+      "integrity": "sha512-+71V0Vbu1ozkeC374C55AXNoks/CeDSfxkakPfvi7rjuwoIQcjVIBvk37/eUZSkXcWEP0xWkFFaJwbFJj5nfog==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "jsonwebtoken": "^9.0.2",

--- a/examples/rust-axum/Cargo.lock
+++ b/examples/rust-axum/Cargo.lock
@@ -265,9 +265,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "prauga-flexdoc-axum"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74382bfef4f7a32db7cce0aa2aceacc9852bb36f9297afbb2b19ba0f2baee148"
+checksum = "d02930fad8e2556e3380ed9fad699f5673bfd8f19ab15c5be02b9def272d495c"
 dependencies = [
  "axum",
  "serde",


### PR DESCRIPTION
## Summary
- refresh the standalone Express, Fastify, and Hono `package-lock.json` files to resolve `@prauga/flexdoc-backend@2.8.0` now that the coordinated JavaScript release is published
- refresh `examples/rust-axum/Cargo.lock` to the published `prauga-flexdoc-axum@0.4.0` crate
- replace the pre-release Go v0.4.0 checksum placeholders in all committed Go example `go.sum` files with the public Go proxy-authoritative checksum after the tag became available

No example manifests, source code, or product versions change in this PR; it only closes the post-publication lock/checksum gap.

## Validation
- `node scripts/check-example-versions.mjs`
- `node scripts/verify-go-example-sum.mjs`
- locked `npm ci` for Express, Fastify, and Hono standalone examples
- `cargo check --locked --manifest-path examples/rust-axum/Cargo.toml`
- `go mod download && go test ./...` for net/http, Gin, Chi, Echo, and Fiber examples
- focused diff guard confirmed only the nine expected lock/checksum files changed