### PR TITLE
Close published FlexDoc 2.8 release documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ No FlexDoc account, hosted dashboard, telemetry service, or runtime CDN is requi
 - **Rust:** Axum, Actix Web
 - **Elixir:** Plug, Phoenix
 
-The backend-coverage program shipped in 2.3.0. API Client development then continued through internal 2.4–2.7 milestones without publishing artificial intermediate FlexDoc package releases. The next coordinated product release is **2.8.0**; see [`docs/api-client-roadmap.md`](./docs/api-client-roadmap.md) for the milestone mapping and definition of done.
+The backend-coverage program shipped in 2.3.0. API Client development then continued through internal 2.4–2.7 milestones without publishing artificial intermediate FlexDoc package releases. The coordinated product line is now **2.8.0**, which adds the standalone API Client milestone catch-up and Postman import; see [`docs/api-client-roadmap.md`](./docs/api-client-roadmap.md) for the milestone mapping and definition of done.
 
 ## Package family
 

--- a/docs/api-client-roadmap.md
+++ b/docs/api-client-roadmap.md
@@ -1,6 +1,6 @@
 # API Client roadmap: FlexDoc 2.3.0 → 2.8.0
 
-FlexDoc 2.3.0 was the last coordinated product release before the API Client workspace grew through several focused development milestones. Those milestone numbers described source-development slices; they were not separate published FlexDoc package releases. The coordinated product line therefore moves directly from published **2.3.0** to the **2.8.0 release candidate** now that the 2.8 source definition of done is satisfied.
+FlexDoc 2.3.0 was the last coordinated product release before the API Client workspace grew through several focused development milestones. Those milestone numbers described source-development slices; they were not separate published FlexDoc package releases. The coordinated product line moved directly from published **2.3.0** to published **2.8.0** after the 2.8 source definition of done was satisfied.
 
 Ecosystem adapters remain independently versioned. `@prauga/flexdoc-client` and `@prauga/flexdoc-backend` carry the coordinated FlexDoc product version because they own and distribute the canonical renderer. Native adapters receive their own semantic-version increment when they package a new renderer, rather than being renamed to the product version.
 
@@ -13,9 +13,9 @@ Ecosystem adapters remain independently versioned. `@prauga/flexdoc-client` and 
 | **2.5** | hierarchical collection/folder/request auth, OpenAPI auth handoff, OAuth access tokens, collection-variable scripting | complete |
 | **2.6** | persisted post-response tests and script output in request history | complete |
 | **2.7** | canonical Try It → API Client request sessions, inherit-first auth defaults, complete browser OAuth grant flows | complete |
-| **2.8** | Postman import into the canonical standalone workspace and coordinated product-version catch-up | complete |
+| **2.8** | Postman import into the canonical standalone workspace and coordinated product-version catch-up | shipped |
 
-Viewer expansion defaults/settings and renderer-option parity landed before the 2.8 release candidate and are included in the 2.8 product surface.
+Viewer expansion defaults/settings and renderer-option parity landed before the 2.8 release and are included in the 2.8 product surface.
 
 ## Architecture rule
 
@@ -25,7 +25,7 @@ Imported data should become ordinary FlexDoc collections, folders, requests, var
 
 ## 2.8.0 definition of done
 
-The 2.8 source release is complete when all of the following are true:
+The 2.8 release is complete with all of the following satisfied:
 
 - [x] standalone API Client workspace is a public client API and works without an OpenAPI document
 - [x] local collections, collection variables, arbitrary-depth folders, saved requests, environments, and bounded history persist in IndexedDB
@@ -37,12 +37,12 @@ The 2.8 source release is complete when all of the following are true:
 - [x] Postman environment JSON imports named environment variables and integrates with normal variable precedence
 - [x] unsupported Postman auth/script/body behavior is surfaced as an import warning rather than silently treated as equivalent
 - [x] the browser import workflow accepts collection and environment files together and imported state survives reload
-- [x] coordinated source versions and example pins represent the 2.8 release candidate
+- [x] coordinated source versions and example pins represent the published 2.8.0 release line
 - [x] canonical standalone renderer assets are rebuilt and synchronized into every adapter that embeds them
-- [x] unit, build, browser E2E, adapter parity, framework coverage, and package/version guards are green on the exact final head
+- [x] unit, build, browser E2E, adapter parity, framework coverage, and package/version guards are green on the exact final source head
 
 ## Release interpretation
 
-Do not retroactively publish artificial 2.4.0, 2.5.0, 2.6.0, or 2.7.0 releases just to fill the numeric gap. They are recorded here as development milestones. The next coordinated JavaScript product release is **2.8.0**.
+Do not retroactively publish artificial 2.4.0, 2.5.0, 2.6.0, or 2.7.0 releases just to fill the numeric gap. They are recorded here as development milestones. The coordinated JavaScript product release is **2.8.0**, published directly after 2.3.0.
 
-For native adapters, increment each package according to its own semantic-version line when publishing the 2.8 renderer. `@prauga/flexdoc-core` remains independently versioned unless the framework-neutral engine itself changes. The CLI also remains independently versioned, but a renderer-consuming CLI release should update its client dependency to the 2.8 line.
+For native adapters, each package remains on its independently versioned semantic-release line while carrying the 2.8 renderer. `@prauga/flexdoc-core` remains independently versioned unless the framework-neutral engine itself changes. The CLI also remains independently versioned and consumes the coordinated 2.8 client line.

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -2,7 +2,7 @@
 
 FlexDoc uses one canonical browser renderer and thin ecosystem adapters. Every adapter release packages or embeds the version-matched renderer rather than implementing its own OpenAPI renderer.
 
-## Published artifacts and release candidates
+## Published artifacts and source versions
 
 | Artifact | Version represented by source | Release tag | Compatibility |
 | --- | --- | --- | --- |
@@ -24,7 +24,7 @@ FlexDoc uses one canonical browser renderer and thin ecosystem adapters. Every a
 
 The table describes the versions encoded by the current source tree. A new source version is not considered published merely because it appears here; publication still requires its matching release workflow to complete successfully.
 
-Versions are intentionally independent across ecosystems. The FlexDoc product release line now advances from shipped `2.3.0` to the `2.8.0` release candidate; the renderer contract, not matching package numbers, is the cross-ecosystem compatibility boundary.
+Versions are intentionally independent across ecosystems. The FlexDoc product release line advanced directly from shipped `2.3.0` to published `2.8.0`; the renderer contract, not matching package numbers, is the cross-ecosystem compatibility boundary.
 
 ## Self-contained adapter artifacts
 
@@ -63,7 +63,7 @@ Before the first publish, configure a NuGet.org Trusted Publishing policy for re
 
 ## Maven Central
 
-The FlexDoc Java family for the 2.8.0 release candidate is coordinated at `0.6.0`:
+The FlexDoc Java family carrying the published 2.8 renderer is coordinated at `0.6.0`:
 
 ```text
 com.prauga.flexdoc:flexdoc-jvm:0.6.0

--- a/examples/go-net-http/README.md
+++ b/examples/go-net-http/README.md
@@ -8,4 +8,4 @@ go run .
 
 Open `http://localhost:3000/docs`.
 
-The example is pinned to `github.com/prauga/flexdoc/adapters/go v0.4.0`. During this unreleased PR, repository CI substitutes the adapter from `../../adapters/go`; after the `adapters/go/v0.4.0` release tag is published, the manifest is directly runnable from a standalone checkout as written.
+The example is pinned to published `github.com/prauga/flexdoc/adapters/go v0.4.0` and resolves through the public Go module infrastructure. Repository CI may substitute the adapter from `../../adapters/go` when validating local source changes.

--- a/examples/javascript-express/README.md
+++ b/examples/javascript-express/README.md
@@ -9,4 +9,4 @@ npm start
 
 Open `http://localhost:3000/docs`.
 
-The FlexDoc dependency is pinned to published `2.8.0` and resolves directly from npm. Repository CI also installs the backend package built from the current commit and boots `/docs` to verify source compatibility.
+The FlexDoc dependency is pinned to `2.8.0` and resolves directly from the published npm package. Repository CI also installs the backend package built from the current commit and boots `/docs` to verify source compatibility.

--- a/examples/javascript-express/README.md
+++ b/examples/javascript-express/README.md
@@ -9,4 +9,4 @@ npm start
 
 Open `http://localhost:3000/docs`.
 
-The FlexDoc dependency is pinned to `2.8.0`. During this release candidate, CI installs the backend package from the same commit and boots `/docs`; after `2.8.0` is published, the manifest is directly runnable as written.
+The FlexDoc dependency is pinned to published `2.8.0` and resolves directly from npm. Repository CI also installs the backend package built from the current commit and boots `/docs` to verify source compatibility.

--- a/examples/javascript-fastify/README.md
+++ b/examples/javascript-fastify/README.md
@@ -9,4 +9,4 @@ npm start
 
 Open `http://localhost:3000/docs`.
 
-The FlexDoc dependency is pinned to published `2.8.0` and resolves directly from npm. Repository CI also installs the backend package built from the current commit and boots the app to verify source compatibility at runtime.
+The FlexDoc dependency is pinned to `2.8.0` and resolves directly from the published npm package. Repository CI also installs the backend package built from the current commit and boots the app to verify source compatibility at runtime.

--- a/examples/javascript-fastify/README.md
+++ b/examples/javascript-fastify/README.md
@@ -9,4 +9,4 @@ npm start
 
 Open `http://localhost:3000/docs`.
 
-The FlexDoc dependency is pinned to `2.8.0`. During this release PR, CI installs the backend package from the same commit and boots the app to verify the integration at runtime; after `2.8.0` is published, the manifest is directly runnable as written.
+The FlexDoc dependency is pinned to published `2.8.0` and resolves directly from npm. Repository CI also installs the backend package built from the current commit and boots the app to verify source compatibility at runtime.

--- a/examples/python-fastapi/README.md
+++ b/examples/python-fastapi/README.md
@@ -12,4 +12,4 @@ uvicorn app:app --reload
 
 Open `http://127.0.0.1:8000/docs`.
 
-`prauga-flexdoc` is pinned to published `0.5.0` and installs directly from PyPI. Repository CI also installs the wheel built from the current commit when validating source changes.
+`prauga-flexdoc` is pinned to `0.5.0` and installs directly from the published PyPI package. Repository CI also installs the wheel built from the current commit when validating source changes.

--- a/examples/python-fastapi/README.md
+++ b/examples/python-fastapi/README.md
@@ -12,4 +12,4 @@ uvicorn app:app --reload
 
 Open `http://127.0.0.1:8000/docs`.
 
-`prauga-flexdoc` is pinned to `0.5.0`. During this release PR, CI installs the wheel built from the same commit; after `0.5.0` is published, the requirements file is directly installable as written.
+`prauga-flexdoc` is pinned to published `0.5.0` and installs directly from PyPI. Repository CI also installs the wheel built from the current commit when validating source changes.

--- a/examples/rust-actix/README.md
+++ b/examples/rust-actix/README.md
@@ -1,3 +1,3 @@
 # Actix Web + FlexDoc
 
-This example uses `prauga-flexdoc-actix` `0.3.0`. CI patches the crate to the local `adapters/rust-actix` release candidate before compiling it.
+This example uses published `prauga-flexdoc-actix` `0.3.0` from crates.io. Repository CI patches the crate to the local `adapters/rust-actix` source when validating adapter changes.

--- a/examples/rust-axum/README.md
+++ b/examples/rust-axum/README.md
@@ -8,4 +8,4 @@ cargo run
 
 Open `http://localhost:3000/docs`.
 
-`prauga-flexdoc-axum` is pinned to published `0.4.0` and resolves directly from crates.io. Repository CI also patches crates.io resolution to `../../adapters/rust` when validating source changes against the local adapter.
+`prauga-flexdoc-axum` is pinned to `0.4.0` and resolves directly from the published crate on crates.io. Repository CI also patches crates.io resolution to `../../adapters/rust` when validating source changes against the local adapter.

--- a/examples/rust-axum/README.md
+++ b/examples/rust-axum/README.md
@@ -8,4 +8,4 @@ cargo run
 
 Open `http://localhost:3000/docs`.
 
-`prauga-flexdoc-axum` is pinned to `0.4.0`. During this release PR, CI patches crates.io resolution to `../../adapters/rust`; after `0.4.0` is published, the manifest is directly runnable as written.
+`prauga-flexdoc-axum` is pinned to published `0.4.0` and resolves directly from crates.io. Repository CI also patches crates.io resolution to `../../adapters/rust` when validating source changes against the local adapter.


### PR DESCRIPTION
## Summary
- mark the coordinated FlexDoc 2.8.0 line as published/shipped instead of a release candidate or future release
- preserve the 2.4–2.7 development-milestone history and independent native-adapter versioning model
- update distribution wording for the published 2.8 renderer line
- remove obsolete pre-publication instructions from Express, Fastify, FastAPI, Go net/http, Rust Axum, and Rust Actix example READMEs while keeping local-source CI validation behavior documented

## Scope
Documentation only. No source code, package versions, manifests, lockfiles, checksums, renderer assets, or runtime behavior change.

## Diff
- 1 commit
- 9 documentation files
- branch is based directly on current `main` after PR #57