### PR TITLE
Establish FlexDoc 2.9.9 performance and production readiness

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,30 @@
+name: Performance Baseline
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22.22.3'
+          cache: npm
+      - run: npm ci
+      - name: Run repeatable FlexDoc performance baseline
+        run: npm run benchmark:performance -- --json performance-results.json
+      - name: Enforce deterministic bundle-size budgets
+        run: npm run check:performance-budgets -- performance-results.json
+      - uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: flexdoc-performance-results
+          path: performance-results.json
+          if-no-files-found: error

--- a/docs/api-client-roadmap.md
+++ b/docs/api-client-roadmap.md
@@ -2,7 +2,7 @@
 
 FlexDoc 2.3.0 was the last coordinated product release before the API Client workspace grew through several focused development milestones. Those milestone numbers described source-development slices; they were not separate published FlexDoc package releases. The coordinated product line moved directly from published **2.3.0** to published **2.8.0** after the 2.8 source definition of done was satisfied.
 
-The current published coordinated product line is **2.9.0**. FlexDoc **2.9.5 is source-complete and prepared as the coordinated parity-hardening and API-host execution release candidate**; the versions recorded in source do not imply publication until the matching release workflows complete successfully.
+The current published coordinated product line is **2.9.5**. FlexDoc **2.9.9 is source-complete in this performance-readiness PR** and remains unpublished until its release preparation and release workflow complete successfully.
 
 Ecosystem adapters remain independently versioned. `@prauga/flexdoc-client` and `@prauga/flexdoc-backend` carry the coordinated FlexDoc product version because they own and distribute the canonical renderer. Native adapters receive their own semantic-version increment when they package a new renderer, rather than being renamed to the product version.
 
@@ -17,7 +17,8 @@ Ecosystem adapters remain independently versioned. `@prauga/flexdoc-client` and 
 | **2.7** | canonical Try It → API Client request sessions, inherit-first auth defaults, complete browser OAuth grant flows | complete |
 | **2.8** | Postman import into the canonical standalone workspace and coordinated product-version catch-up | shipped |
 | **2.9** | shared request executor, collection/folder runner product UI, scripting IntelliSense, grouped run history, and full request-history inspector | shipped |
-| **2.9.5** | REST workspace parity hardening plus capability-gated Node API-host execution for browser-impossible request features | source complete / release candidate |
+| **2.9.5** | REST workspace parity hardening plus capability-gated Node API-host execution for browser-impossible request features | shipped |
+| **2.9.9** | measured performance baseline, production delivery hardening, host-page caching/revalidation, and regression budgets before Runtime Intelligence | source complete / pending merge |
 
 Viewer expansion defaults/settings and renderer-option parity landed before the 2.8 release and are included in the 2.8 product surface.
 
@@ -73,7 +74,7 @@ The 2.9 source release candidate is complete with the following satisfied:
 - [x] future-version example manifests and the deterministic future-tag Go checksum represent the release-candidate source tree without pretending registry artifacts already exist
 - [x] the canonical standalone renderer is rebuilt and synchronized across committed adapter assets, with parity checks passing before the release candidate is proposed
 
-2.9.0 is published. 2.9.5 is now prepared as a separate coordinated release candidate; publication still starts only after this exact release-candidate PR is green.
+2.9.0 is published. 2.9.5 is also published; 2.9.9 is the current source-complete performance-readiness milestone pending merge and release preparation.
 
 ## 2.8.0 definition of done
 
@@ -92,6 +93,22 @@ The 2.8 release is complete with all of the following satisfied:
 - [x] coordinated source versions and example pins represent the published 2.8.0 release line
 - [x] canonical standalone renderer assets are rebuilt and synchronized into every adapter that embeds them
 - [x] unit, build, browser E2E, adapter parity, framework coverage, and package/version guards are green on the exact final source head
+
+## 2.9.9 Performance & production readiness
+
+2.9.9 is intentionally the final 2.x engineering gate before Runtime Intelligence. It does not reopen Postman/Scalar parity work. It establishes measurable production cost, removes avoidable documentation-host overhead, and turns performance into a regression-tested property of the product.
+
+Definition of done:
+
+- [x] benchmark 100 KiB, 1 MiB, 5 MiB, and 10 MiB OpenAPI documents on a repeatable harness
+- [x] record canonical renderer raw/gzip/Brotli size and enforce deterministic bundle-size regression budgets in CI
+- [x] serialize generated Node host pages once per configured integration instead of once per docs request
+- [x] support ETag-based docs-page revalidation while preserving `no-cache` freshness semantics
+- [x] measure Node process startup, backend import/setup time, and RSS delta in clean child processes
+- [x] verify normal application routes incur no FlexDoc request-path work through path-scoped integration regressions
+- [x] document compression, caching, replica-stable ETags, multi-pod/process-local cache behavior, and detached/static deployment guidance
+
+The architectural priority test remains unchanged: **could Scalar implement this without being installed inside the backend?** Performance work is justified here because backend installation is part of FlexDoc's differentiation; the cost of that installation must be explicit, small, and continuously measurable.
 
 ## Backend-native roadmap after 2.9.5
 
@@ -113,6 +130,6 @@ Cloud collaboration, teams, enterprise controls, CI workflow, and additional pro
 
 ## Release interpretation
 
-Do not retroactively publish artificial 2.4.0, 2.5.0, 2.6.0, or 2.7.0 releases just to fill the numeric gap. They are recorded here as development milestones. The coordinated JavaScript product line moved through published **2.8.0** to published **2.9.0**. The active source release candidate targets **2.9.5** and remains unpublished until its release workflow is explicitly started after this exact release-candidate PR is green.
+Do not retroactively publish artificial 2.4.0, 2.5.0, 2.6.0, or 2.7.0 releases just to fill the numeric gap. They are recorded here as development milestones. The coordinated JavaScript product line moved through published **2.8.0**, **2.9.0**, and **2.9.5**. FlexDoc **2.9.9** is the final 2.x performance-readiness milestone before 3.0 and is not published until its dedicated release preparation and release workflow complete successfully.
 
 For native adapters, each package remains on its independently versioned semantic-release line while carrying the current coordinated renderer. `@prauga/flexdoc-core` remains independently versioned unless the framework-neutral engine itself changes. The CLI also remains independently versioned and consumes the coordinated client line.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,55 @@
+# Performance and production readiness
+
+FlexDoc 2.9.9 is the production-readiness gate before 3.0 Runtime Intelligence. The goal is to answer a simple operator question with measurements: **what does installing FlexDoc cost the service that hosts it?**
+
+## What we measure
+
+The repository owns a repeatable Node baseline through `npm run benchmark:performance` and the `Performance Baseline` GitHub Actions workflow.
+
+The baseline records:
+
+- canonical standalone JavaScript and CSS raw, gzip, and Brotli sizes;
+- OpenAPI host-page serialization for approximately 100 KiB, 1 MiB, 5 MiB, and 10 MiB specifications, including p50/p95/p99;
+- first render cost versus warm cached-page lookup cost and 100-request cold-cache coalescing;
+- clean Node process startup versus FlexDoc backend import/setup time and RSS;
+- generated host-page size and benchmark-process memory snapshot;
+- the exact Node/platform metadata used for the run.
+
+Workflow results are uploaded as `performance-results.json`. Wall-clock measurements remain evidence rather than hard CI budgets because shared runners are noisy. Deterministic bundle sizes are stable enough to gate now, so CI enforces explicit raw/gzip/Brotli ceilings through `npm run check:performance-budgets -- performance-results.json`.
+
+## Regression budgets
+
+The 2.9.9 baseline establishes intentionally small headroom above the repeated measured bundle sizes. A future intentional bundle increase should update these budgets in the same reviewed change rather than bypassing the check.
+
+| Asset | Raw budget | Gzip budget | Brotli budget | Repeated baseline |
+| --- | ---: | ---: | ---: | ---: |
+| standalone JavaScript | 540 KiB | 160 KiB | 135 KiB | ~511 / 151 / 126.6 KiB |
+| standalone CSS | 41 KiB | 8.2 KiB | 7 KiB | ~38.1 / 7.6 / 6.5 KiB |
+
+Wall-clock serialization, startup, and RSS measurements continue to be recorded on every run. They are not converted into absolute shared-runner SLAs in 2.9.9; the regression-tested runtime properties are structural instead: one page serialization per integration, cold-request coalescing, path-scoped registration, and deterministic cross-replica ETags.
+
+## Host overhead contract
+
+FlexDoc must not add work to ordinary application API requests. Runtime integration registers documentation routes under the configured docs path; it does not install request processing on unrelated application routes. The Express regression suite asserts that every registered handler remains under the configured docs prefix and that no global middleware is installed. Host execution remains opt-in and does not create a background polling loop.
+
+For the documentation path itself, the generated host page is immutable for the lifetime of the configured integration because its spec/options are already resolved once. Node hosts therefore serialize that page once, cache it, and reuse it for warm requests. The page is served with `Cache-Control: no-cache` plus an ETag so browsers and proxies can revalidate without transferring the HTML again when unchanged.
+
+Renderer assets remain version-addressed and use `public, max-age=31536000, immutable`. ETags are content-derived, so independent application replicas serving the same spec/options produce the same validator without shared cache state; each replica keeps only its own in-process page promise/body.
+
+## Deployment choices
+
+The embedded mode optimizes for zero normal-route overhead and cheap docs requests. Teams that require literally zero FlexDoc runtime presence can continue to export/serve static documentation through the CLI or their static hosting pipeline.
+
+Compression should normally be provided by the application's HTTP stack, ingress, CDN, or reverse proxy. The benchmark reports gzip/Brotli transfer sizes so operators can verify the expected compressed footprint without FlexDoc introducing a second compression layer inside every adapter.
+
+## 2.9.9 completion gate
+
+Before 3.0 work starts, FlexDoc should have:
+
+- a checked-in repeatable benchmark harness and CI artifact;
+- measured bundle and large-spec baselines;
+- no repeated host-page serialization on warm docs requests, including coalesced concurrent cold requests;
+- conditional revalidation for generated docs HTML with replica-stable content ETags;
+- measured Node backend import/setup process and RSS cost;
+- explicit production guidance for compression, caching, static deployment, multi-replica behavior, and normal API hot-path isolation;
+- deterministic bundle-size regression budgets derived from repeated baseline output, with wall-clock metrics retained as non-blocking evidence.

--- a/examples/go-chi/go.sum
+++ b/examples/go-chi/go.sum
@@ -1,4 +1,4 @@
-github.com/prauga/flexdoc/adapters/go v0.5.1 h1:Bg8qqoJkp+DKnvC+8iG9E85VdhiWjrMT6cPHHT9ULCk=
+github.com/prauga/flexdoc/adapters/go v0.5.1 h1:cJDgPWz7fMQ3BYaAbxNJcF928yRf3cG0kYpFQ9oy2HY=
 github.com/prauga/flexdoc/adapters/go v0.5.1/go.mod h1:tMdyVXq3OY5uhengBClaE9XC0/fD/BuMIx2GUcDMi9k=
 github.com/go-chi/chi/v5 v5.3.2 h1:5YQkICvTCSZ25hoRsyJazN0scjzKGiu4VAUc7H1o1nY=
 github.com/go-chi/chi/v5 v5.3.2/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=

--- a/examples/go-echo/go.sum
+++ b/examples/go-echo/go.sum
@@ -1,4 +1,4 @@
-github.com/prauga/flexdoc/adapters/go v0.5.1 h1:Bg8qqoJkp+DKnvC+8iG9E85VdhiWjrMT6cPHHT9ULCk=
+github.com/prauga/flexdoc/adapters/go v0.5.1 h1:cJDgPWz7fMQ3BYaAbxNJcF928yRf3cG0kYpFQ9oy2HY=
 github.com/prauga/flexdoc/adapters/go v0.5.1/go.mod h1:tMdyVXq3OY5uhengBClaE9XC0/fD/BuMIx2GUcDMi9k=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/examples/go-fiber/go.sum
+++ b/examples/go-fiber/go.sum
@@ -1,4 +1,4 @@
-github.com/prauga/flexdoc/adapters/go v0.5.1 h1:Bg8qqoJkp+DKnvC+8iG9E85VdhiWjrMT6cPHHT9ULCk=
+github.com/prauga/flexdoc/adapters/go v0.5.1 h1:cJDgPWz7fMQ3BYaAbxNJcF928yRf3cG0kYpFQ9oy2HY=
 github.com/prauga/flexdoc/adapters/go v0.5.1/go.mod h1:tMdyVXq3OY5uhengBClaE9XC0/fD/BuMIx2GUcDMi9k=
 github.com/andybalholm/brotli v1.2.2 h1:HzTuoo2ErYQqf5qvcJInB8uvqSVxRttzkFexPWtnceM=
 github.com/andybalholm/brotli v1.2.2/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=

--- a/examples/go-gin/go.sum
+++ b/examples/go-gin/go.sum
@@ -1,4 +1,4 @@
-github.com/prauga/flexdoc/adapters/go v0.5.1 h1:Bg8qqoJkp+DKnvC+8iG9E85VdhiWjrMT6cPHHT9ULCk=
+github.com/prauga/flexdoc/adapters/go v0.5.1 h1:cJDgPWz7fMQ3BYaAbxNJcF928yRf3cG0kYpFQ9oy2HY=
 github.com/prauga/flexdoc/adapters/go v0.5.1/go.mod h1:tMdyVXq3OY5uhengBClaE9XC0/fD/BuMIx2GUcDMi9k=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=

--- a/examples/go-net-http/go.sum
+++ b/examples/go-net-http/go.sum
@@ -1,2 +1,2 @@
-github.com/prauga/flexdoc/adapters/go v0.5.1 h1:Bg8qqoJkp+DKnvC+8iG9E85VdhiWjrMT6cPHHT9ULCk=
+github.com/prauga/flexdoc/adapters/go v0.5.1 h1:cJDgPWz7fMQ3BYaAbxNJcF928yRf3cG0kYpFQ9oy2HY=
 github.com/prauga/flexdoc/adapters/go v0.5.1/go.mod h1:tMdyVXq3OY5uhengBClaE9XC0/fD/BuMIx2GUcDMi9k=

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "sync:adapter-assets": "node scripts/sync-adapter-assets.mjs",
     "check:adapter-assets": "node scripts/sync-adapter-assets.mjs --check",
     "check:example-versions": "node scripts/check-example-versions.mjs",
+    "benchmark:performance": "npm run build:client && npm run build:backend && node scripts/performance/benchmark.mjs",
+    "check:performance-budgets": "node scripts/performance/check-budgets.mjs",
     "lint": "npm run lint -w packages/client && npm run lint -w examples/nestjs",
     "audit": "npm audit --audit-level=low",
     "example:nestjs": "npm run start:dev -w examples/nestjs",

--- a/packages/backend/src/framework-adapters.test.ts
+++ b/packages/backend/src/framework-adapters.test.ts
@@ -37,6 +37,16 @@ describe('setupFastifyFlexDoc', () => {
       expect.any(Object),
       expect.objectContaining({ rendererVersion: 'test-renderer-version' })
     );
+    expect(state.headers.ETag).toMatch(/^"/);
+
+    const second = replyState();
+    await routes.get('/docs').handler({ headers: {} }, second.reply);
+    expect(generateFlexDocHTML).toHaveBeenCalledTimes(1);
+
+    const revalidated = replyState();
+    await routes.get('/docs').handler({ headers: { 'if-none-match': state.headers.ETag } }, revalidated.reply);
+    expect(revalidated.state.code).toBe(304);
+    expect(generateFlexDocHTML).toHaveBeenCalledTimes(1);
   });
 
   it('protects Fastify routes when docs auth is configured', async () => {

--- a/packages/backend/src/framework-adapters.ts
+++ b/packages/backend/src/framework-adapters.ts
@@ -6,6 +6,7 @@ import { setupFlexDoc } from './setup';
 import { generateFlexDocHTML } from './template';
 import { createHostExecutionState, publicHostExecutionOptions } from './host-execution';
 import { hostExecutionRequestOrigin, runHostCookiesRoute, runHostExecutionRoute } from './host-execution-route';
+import { createCachedFlexDocPage, matchesFlexDocEtag } from './page-cache';
 
 export interface ExpressLikeApplication {
   use(path: string, handler: (req: any, res: any, next?: any) => void | Promise<void>): void;
@@ -123,6 +124,16 @@ function setupFastifyFlexDocInternal(
     return remoteSpecPromise;
   };
 
+  const getPage = createCachedFlexDocPage(async () => {
+    const assets = getRendererAssets();
+    return generateFlexDocHTML(await resolvedSpec(), {
+      ...(options.options || {}),
+      rendererBasePath,
+      rendererVersion: assets.version,
+      hostExecutionPublic: hostRouteAvailable ? publicHostExecutionOptions(hostExecutionState, rendererBasePath) : undefined,
+    });
+  });
+
   const sendHostResult = (reply: FastifyLikeReply, result: { status: number; headers: Record<string, string>; body: string }) => {
     let target = reply.code(result.status);
     for (const [name, value] of Object.entries(result.headers)) target = target.header(name, value);
@@ -154,19 +165,17 @@ function setupFastifyFlexDocInternal(
     return reply.type('text/css; charset=utf-8').header('Cache-Control', 'public, max-age=31536000, immutable').send(assets.css);
   });
 
-  app.get(normalizedPath, routeOptions, async (_request, reply) => {
+  app.get(normalizedPath, routeOptions, async (request, reply) => {
     try {
-      const assets = getRendererAssets();
-      const html = generateFlexDocHTML(await resolvedSpec(), {
-        ...(options.options || {}),
-        rendererBasePath,
-        rendererVersion: assets.version,
-        hostExecutionPublic: hostRouteAvailable ? publicHostExecutionOptions(hostExecutionState, rendererBasePath) : undefined,
-      });
-      return reply
+      const page = await getPage();
+      let target = reply
         .type('text/html; charset=utf-8')
         .header('Cache-Control', 'no-cache')
-        .send(html);
+        .header('ETag', page.etag);
+      if (matchesFlexDocEtag(request.headers['if-none-match'], page.etag)) {
+        return target.code(304).send('');
+      }
+      return target.send(page.body);
     } catch (error) {
       return reply.code(502).type('text/plain; charset=utf-8').send(`Unable to load OpenAPI specification: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }

--- a/packages/backend/src/hono-adapter.test.ts
+++ b/packages/backend/src/hono-adapter.test.ts
@@ -20,10 +20,14 @@ type HonoResult = {
   headers: Record<string, string>;
 };
 
-function createContext(authorization?: string): HonoLikeContext {
+function createContext(authorization?: string, extraHeaders: Record<string, string> = {}): HonoLikeContext {
   return {
     req: {
-      header: (name: string) => name.toLowerCase() === 'authorization' ? authorization : undefined,
+      header: (name: string) => {
+        const normalized = name.toLowerCase();
+        if (normalized === 'authorization') return authorization;
+        return extraHeaders[normalized];
+      },
     },
     body: (body, status = 200, headers = {}) => ({ body, status, headers }),
   };
@@ -72,6 +76,14 @@ describe('setupHonoFlexDoc', () => {
         hostExecutionPublic: expect.objectContaining({ available: true, endpoint: '/docs/__flexdoc/execute' }),
       }),
     );
+    expect(result.headers.ETag).toMatch(/^"/);
+
+    await handlers.get('/docs/')!(createContext());
+    expect(generateFlexDocHTML).toHaveBeenCalledTimes(1);
+
+    const revalidated = await handlers.get('/docs')!(createContext(undefined, { 'if-none-match': result.headers.ETag })) as HonoResult;
+    expect(revalidated.status).toBe(304);
+    expect(generateFlexDocHTML).toHaveBeenCalledTimes(1);
   });
 
   it('protects docs and assets with the same basic auth contract as setupFlexDoc', async () => {

--- a/packages/backend/src/hono-adapter.ts
+++ b/packages/backend/src/hono-adapter.ts
@@ -4,6 +4,7 @@ import { getRendererAssets } from './renderer-assets';
 import { generateFlexDocHTML } from './template';
 import { createHostExecutionState, publicHostExecutionOptions } from './host-execution';
 import { hostExecutionRequestOrigin, runHostCookiesRoute, runHostExecutionRoute } from './host-execution-route';
+import { createCachedFlexDocPage, matchesFlexDocEtag } from './page-cache';
 
 export interface HonoLikeRequest {
   header(name: string): string | undefined;
@@ -52,23 +53,32 @@ export function setupHonoFlexDoc(
     });
   };
 
-  const page = (context: HonoLikeContext) => {
-    const denied = denyUnauthorized(context);
-    if (denied !== undefined) return denied;
-
+  const getPage = createCachedFlexDocPage(() => {
     const assets = getRendererAssets();
     const spec = (options.spec || null) as Parameters<typeof generateFlexDocHTML>[0];
-    const html = generateFlexDocHTML(spec, {
+    return generateFlexDocHTML(spec, {
       ...(options.options || {}),
       specUrl: options.specUrl,
       rendererBasePath,
       rendererVersion: assets.version,
       hostExecutionPublic: hostRouteAvailable ? publicHostExecutionOptions(hostExecutionState, rendererBasePath) : undefined,
     });
-    return context.body(html, 200, {
+  });
+
+  const page = async (context: HonoLikeContext) => {
+    const denied = denyUnauthorized(context);
+    if (denied !== undefined) return denied;
+
+    const cachedPage = await getPage();
+    const headers = {
       'Content-Type': 'text/html; charset=utf-8',
       'Cache-Control': 'no-cache',
-    });
+      'ETag': cachedPage.etag,
+    };
+    if (matchesFlexDocEtag(context.req.header('If-None-Match'), cachedPage.etag)) {
+      return context.body('', 304, headers);
+    }
+    return context.body(cachedPage.body, 200, headers);
   };
 
   const honoHeaders = (context: HonoLikeContext) => ({

--- a/packages/backend/src/page-cache.test.ts
+++ b/packages/backend/src/page-cache.test.ts
@@ -1,0 +1,53 @@
+import {
+  createCachedFlexDocPage,
+  flexDocPageEtag,
+  matchesFlexDocEtag,
+} from './page-cache';
+
+describe('FlexDoc page cache', () => {
+  it('renders once and reuses the exact cached page', async () => {
+    const render = jest.fn(() => '<html>cached</html>');
+    const getPage = createCachedFlexDocPage(render);
+
+    const first = await getPage();
+    const second = await getPage();
+
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first);
+    expect(first.etag).toBe(flexDocPageEtag(first.body));
+  });
+
+  it('drops a failed render so a later request can retry', async () => {
+    const render = jest.fn()
+      .mockRejectedValueOnce(new Error('temporary failure'))
+      .mockResolvedValueOnce('<html>recovered</html>');
+    const getPage = createCachedFlexDocPage(render);
+
+    await expect(getPage()).rejects.toThrow('temporary failure');
+    await expect(getPage()).resolves.toEqual(expect.objectContaining({ body: '<html>recovered</html>' }));
+    expect(render).toHaveBeenCalledTimes(2);
+  });
+
+  it('coalesces concurrent cold requests and produces stable ETags across host instances', async () => {
+    const render = jest.fn(async () => '<html>shared</html>');
+    const firstHost = createCachedFlexDocPage(render);
+
+    const pages = await Promise.all(Array.from({ length: 100 }, () => firstHost()));
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(pages.every((page) => page === pages[0])).toBe(true);
+
+    const secondHost = createCachedFlexDocPage(() => '<html>shared</html>');
+    const secondPage = await secondHost();
+    expect(secondPage.etag).toBe(pages[0].etag);
+    expect(secondPage.body).toBe(pages[0].body);
+  });
+
+  it('accepts strong, weak, wildcard, and comma-separated If-None-Match values', () => {
+    const etag = flexDocPageEtag('docs');
+    expect(matchesFlexDocEtag(etag, etag)).toBe(true);
+    expect(matchesFlexDocEtag(`W/${etag}`, etag)).toBe(true);
+    expect(matchesFlexDocEtag('*', etag)).toBe(true);
+    expect(matchesFlexDocEtag(`"other", ${etag}`, etag)).toBe(true);
+    expect(matchesFlexDocEtag('"other"', etag)).toBe(false);
+  });
+});

--- a/packages/backend/src/page-cache.ts
+++ b/packages/backend/src/page-cache.ts
@@ -1,0 +1,42 @@
+import { createHash } from 'crypto';
+
+export interface CachedFlexDocPage {
+  body: string;
+  etag: string;
+}
+
+export function flexDocPageEtag(body: string): string {
+  const digest = createHash('sha256').update(body).digest('base64url');
+  return `"${digest}"`;
+}
+
+export function matchesFlexDocEtag(
+  value: string | string[] | undefined,
+  etag: string,
+): boolean {
+  if (!value) return false;
+  const header = Array.isArray(value) ? value.join(',') : value;
+  return header
+    .split(',')
+    .map((candidate) => candidate.trim())
+    .some((candidate) => candidate === '*' || candidate === etag || candidate === `W/${etag}`);
+}
+
+export function createCachedFlexDocPage(
+  render: () => string | Promise<string>,
+): () => Promise<CachedFlexDocPage> {
+  let pending: Promise<CachedFlexDocPage> | null = null;
+
+  return () => {
+    if (!pending) {
+      pending = Promise.resolve()
+        .then(render)
+        .then((body) => ({ body, etag: flexDocPageEtag(body) }))
+        .catch((error) => {
+          pending = null;
+          throw error;
+        });
+    }
+    return pending;
+  };
+}

--- a/packages/backend/src/setup.test.ts
+++ b/packages/backend/src/setup.test.ts
@@ -50,6 +50,13 @@ describe('setupFlexDoc', () => {
     expect(handlers.has('/docs/__flexdoc/cookies')).toBe(false);
   });
 
+  it('only registers path-scoped handlers and leaves unrelated application routes untouched', () => {
+    setupFlexDoc(mockApp, '/docs', { spec: { openapi: '3.0.0' } });
+
+    expect([...handlers.keys()].every((path) => path.startsWith('/docs'))).toBe(true);
+    expect(mockApp.use).not.toHaveBeenCalledWith(expect.any(Function));
+  });
+
   it('does not register or advertise host execution unless explicitly enabled', async () => {
     setupFlexDoc(mockApp, '/docs', { spec: { openapi: '3.0.0' } });
     expect(handlers.has('/docs/__flexdoc/execute')).toBe(false);
@@ -97,6 +104,25 @@ describe('setupFlexDoc', () => {
       'text/html; charset=utf-8'
     );
     expect(mockRes.send).toHaveBeenCalledWith('<html>Mocked HTML</html>');
+  });
+
+  it('serializes the docs page once and revalidates it with an ETag', async () => {
+    setupFlexDoc(mockApp, '/docs', { spec: { openapi: '3.0.0' } });
+    const page = handlers.get('/docs')!;
+
+    await page(mockReq, mockRes);
+    const etagCall = mockRes.setHeader.mock.calls.find(([name]: [string]) => name === 'ETag');
+    expect(etagCall?.[1]).toMatch(/^"/);
+
+    mockReq.headers = { 'if-none-match': etagCall?.[1] };
+    mockRes.send.mockClear();
+    mockRes.end.mockClear();
+    await page(mockReq, mockRes);
+
+    expect(generateFlexDocHTML).toHaveBeenCalledTimes(1);
+    expect(mockRes.statusCode).toBe(304);
+    expect(mockRes.send).not.toHaveBeenCalled();
+    expect(mockRes.end).toHaveBeenCalled();
   });
 
   it('returns a gateway error when specUrl cannot be loaded', async () => {

--- a/packages/backend/src/setup.ts
+++ b/packages/backend/src/setup.ts
@@ -6,6 +6,7 @@ import * as http from 'http';
 import * as https from 'https';
 import { createHostExecutionState, publicHostExecutionOptions } from './host-execution';
 import { hostExecutionRequestOrigin, readNodeRequestBody, runHostCookiesRoute, runHostExecutionRoute } from './host-execution-route';
+import { createCachedFlexDocPage, matchesFlexDocEtag } from './page-cache';
 
 interface AppWithUse {
   use: (
@@ -139,6 +140,17 @@ export function setupFlexDoc(
     return remoteSpecPromise;
   };
 
+  const getPage = createCachedFlexDocPage(async () => {
+    const resolvedSpec = await getSpec();
+    const rendererAssets = getRendererAssets();
+    return generateFlexDocHTML(resolvedSpec, {
+      ...(flexDocOptions || {}),
+      rendererBasePath,
+      rendererVersion: rendererAssets.version,
+      hostExecutionPublic: publicHostExecutionOptions(hostExecutionState, rendererBasePath),
+    });
+  });
+
   const sendHostResult = (res: any, result: Awaited<ReturnType<typeof runHostExecutionRoute>> | ReturnType<typeof runHostCookiesRoute>) => {
     res.statusCode = result.status;
     for (const [name, value] of Object.entries(result.headers)) res.setHeader(name, value);
@@ -162,19 +174,17 @@ export function setupFlexDoc(
     });
   }
 
-  app.use(normalizedPath, async (_req: any, res: any) => {
+  app.use(normalizedPath, async (req: any, res: any) => {
     try {
-      const resolvedSpec = await getSpec();
-      const rendererAssets = getRendererAssets();
-      const html = generateFlexDocHTML(resolvedSpec, {
-        ...(flexDocOptions || {}),
-        rendererBasePath,
-        rendererVersion: rendererAssets.version,
-        hostExecutionPublic: publicHostExecutionOptions(hostExecutionState, rendererBasePath),
-      });
+      const page = await getPage();
       res.setHeader('Content-Type', 'text/html; charset=utf-8');
       res.setHeader('Cache-Control', 'no-cache');
-      res.send(html);
+      res.setHeader('ETag', page.etag);
+      if (matchesFlexDocEtag(req.headers?.['if-none-match'], page.etag)) {
+        res.statusCode = 304;
+        return res.end();
+      }
+      res.send(page.body);
     } catch (error) {
       res.statusCode = 502;
       res.setHeader('Content-Type', 'text/plain; charset=utf-8');

--- a/scripts/performance/benchmark.mjs
+++ b/scripts/performance/benchmark.mjs
@@ -1,0 +1,245 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { performance } from 'node:perf_hooks';
+import { gzipSync, brotliCompressSync } from 'node:zlib';
+
+const require = createRequire(import.meta.url);
+const root = path.resolve(import.meta.dirname, '../..');
+const { generateFlexDocHTML } = require(path.join(root, 'packages/backend/dist/template.js'));
+const { createCachedFlexDocPage } = require(path.join(root, 'packages/backend/dist/page-cache.js'));
+
+function percentile(values, fraction) {
+  const ordered = [...values].sort((a, b) => a - b);
+  const index = Math.min(ordered.length - 1, Math.floor((ordered.length - 1) * fraction));
+  return ordered[index] || 0;
+}
+
+function stats(values) {
+  return {
+    minMs: Math.min(...values),
+    p50Ms: percentile(values, 0.50),
+    p95Ms: percentile(values, 0.95),
+    p99Ms: percentile(values, 0.99),
+    maxMs: Math.max(...values),
+  };
+}
+
+function buildSpec(targetBytes) {
+  const operation = {
+    get: {
+      summary: 'Benchmark endpoint',
+      description: 'Representative endpoint used by the FlexDoc performance harness.',
+      parameters: [
+        { name: 'id', in: 'query', schema: { type: 'string' } },
+        { name: 'limit', in: 'query', schema: { type: 'integer', default: 20 } },
+      ],
+      responses: {
+        200: {
+          description: 'OK',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  id: { type: 'string' },
+                  payload: { type: 'string', example: 'x'.repeat(256) },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+  const base = { openapi: '3.1.0', info: { title: 'FlexDoc benchmark', version: '1.0.0' }, paths: {} };
+  const sampleBytes = Buffer.byteLength(JSON.stringify({ '/benchmark/0': operation }));
+  const baseBytes = Buffer.byteLength(JSON.stringify(base));
+  const count = Math.max(1, Math.ceil((targetBytes - baseBytes) / sampleBytes));
+  for (let i = 0; i < count; i += 1) base.paths[`/benchmark/${i}`] = operation;
+  return base;
+}
+
+async function measure(fn, iterations) {
+  const timings = [];
+  for (let i = 0; i < iterations; i += 1) {
+    const start = performance.now();
+    await fn();
+    timings.push(performance.now() - start);
+  }
+  return stats(timings);
+}
+
+function bundleMetric(file) {
+  const body = fs.readFileSync(file);
+  return {
+    rawBytes: body.length,
+    gzipBytes: gzipSync(body).length,
+    brotliBytes: brotliCompressSync(body).length,
+  };
+}
+
+function childSample(script) {
+  const started = performance.now();
+  const child = spawnSync(process.execPath, ['-e', script], {
+    cwd: root,
+    encoding: 'utf8',
+    env: { ...process.env, NODE_ENV: 'production' },
+  });
+  const elapsedMs = performance.now() - started;
+  if (child.status !== 0) {
+    throw new Error(`child benchmark failed: ${child.stderr || child.stdout}`);
+  }
+  const line = child.stdout.trim().split(/\r?\n/).at(-1);
+  return { elapsedMs, payload: JSON.parse(line) };
+}
+
+function childProcessSeries(script, iterations = 7) {
+  const samples = Array.from({ length: iterations }, () => childSample(script));
+  const elapsed = samples.map((sample) => sample.elapsedMs);
+  const rss = samples.map((sample) => sample.payload.rssBytes);
+  const importTimes = samples
+    .map((sample) => sample.payload.importMs)
+    .filter((value) => typeof value === 'number');
+  const setupTimes = samples
+    .map((sample) => sample.payload.setupMs)
+    .filter((value) => typeof value === 'number');
+  return {
+    processElapsed: stats(elapsed),
+    rssP50Bytes: percentile(rss, 0.50),
+    import: importTimes.length ? stats(importTimes) : undefined,
+    setup: setupTimes.length ? stats(setupTimes) : undefined,
+  };
+}
+
+const targets = [100 * 1024, 1024 * 1024, 5 * 1024 * 1024, 10 * 1024 * 1024];
+const cases = [];
+for (const targetBytes of targets) {
+  const spec = buildSpec(targetBytes);
+  const actualSpecBytes = Buffer.byteLength(JSON.stringify(spec));
+  const uncachedIterations = targetBytes >= 5 * 1024 * 1024 ? 5 : 12;
+  const uncached = await measure(
+    () => generateFlexDocHTML(spec, { rendererBasePath: '/docs/__flexdoc', rendererVersion: 'benchmark' }),
+    uncachedIterations,
+  );
+  const getPage = createCachedFlexDocPage(() => generateFlexDocHTML(spec, {
+    rendererBasePath: '/docs/__flexdoc',
+    rendererVersion: 'benchmark',
+  }));
+  const first = await measure(() => getPage(), 1);
+  const page = await getPage();
+  const warm = await measure(() => getPage(), 500);
+
+  const concurrentPage = createCachedFlexDocPage(() => generateFlexDocHTML(spec, {
+    rendererBasePath: '/docs/__flexdoc',
+    rendererVersion: 'benchmark',
+  }));
+  const concurrentStarted = performance.now();
+  const concurrentResults = await Promise.all(Array.from({ length: 100 }, () => concurrentPage()));
+  const concurrentColdMs = performance.now() - concurrentStarted;
+  if (!concurrentResults.every((entry) => entry === concurrentResults[0])) {
+    throw new Error('concurrent cold page requests did not coalesce to one cached page');
+  }
+
+  cases.push({
+    targetSpecBytes: targetBytes,
+    actualSpecBytes,
+    htmlBytes: Buffer.byteLength(page.body),
+    uncachedRender: uncached,
+    cachedFirstRender: first,
+    cachedWarmLookup: warm,
+    concurrentCold100TotalMs: concurrentColdMs,
+  });
+}
+
+const backendEntry = JSON.stringify(path.join(root, 'packages/backend/dist/index.js'));
+const setupEntry = JSON.stringify(path.join(root, 'packages/backend/dist/setup.js'));
+const baselineProcess = childProcessSeries("console.log(JSON.stringify({rssBytes: process.memoryUsage().rss}))");
+const backendProcess = childProcessSeries(`
+  const { performance } = require('node:perf_hooks');
+  const started = performance.now();
+  require(${backendEntry});
+  const importMs = performance.now() - started;
+  console.log(JSON.stringify({rssBytes: process.memoryUsage().rss, importMs}));
+`);
+const setupProcess = childProcessSeries(`
+  const { performance } = require('node:perf_hooks');
+  const importStarted = performance.now();
+  const { setupFlexDoc } = require(${setupEntry});
+  const importMs = performance.now() - importStarted;
+  const app = { use() {} };
+  const setupStarted = performance.now();
+  setupFlexDoc(app, '/docs', { spec: { openapi: '3.1.0', info: { title: 'Benchmark', version: '1' }, paths: {} } });
+  const setupMs = performance.now() - setupStarted;
+  console.log(JSON.stringify({rssBytes: process.memoryUsage().rss, importMs, setupMs}));
+`);
+
+const standaloneDir = path.join(root, 'packages/client/dist/standalone');
+const results = {
+  generatedAt: new Date().toISOString(),
+  node: process.version,
+  platform: `${process.platform}/${process.arch}`,
+  benchmarkProcessMemory: process.memoryUsage(),
+  processCost: {
+    baseline: baselineProcess,
+    backendImport: backendProcess,
+    backendSetup: setupProcess,
+    backendImportRssDeltaP50Bytes: backendProcess.rssP50Bytes - baselineProcess.rssP50Bytes,
+    backendSetupRssDeltaP50Bytes: setupProcess.rssP50Bytes - baselineProcess.rssP50Bytes,
+  },
+  bundles: {
+    javascript: bundleMetric(path.join(standaloneDir, 'flexdoc.standalone.js')),
+    css: bundleMetric(path.join(standaloneDir, 'flexdoc.standalone.css')),
+  },
+  hostPageCases: cases,
+};
+
+console.log('FlexDoc performance baseline');
+console.log(`Node ${results.node} on ${results.platform}`);
+console.table(cases.map((entry) => ({
+  specMiB: (entry.actualSpecBytes / 1024 / 1024).toFixed(2),
+  htmlMiB: (entry.htmlBytes / 1024 / 1024).toFixed(2),
+  uncachedP50Ms: entry.uncachedRender.p50Ms.toFixed(2),
+  uncachedP95Ms: entry.uncachedRender.p95Ms.toFixed(2),
+  uncachedP99Ms: entry.uncachedRender.p99Ms.toFixed(2),
+  cachedWarmP99Ms: entry.cachedWarmLookup.p99Ms.toFixed(4),
+  coldConcurrent100Ms: entry.concurrentCold100TotalMs.toFixed(2),
+})));
+console.table(Object.entries(results.bundles).map(([name, metric]) => ({
+  asset: name,
+  rawKiB: (metric.rawBytes / 1024).toFixed(1),
+  gzipKiB: (metric.gzipBytes / 1024).toFixed(1),
+  brotliKiB: (metric.brotliBytes / 1024).toFixed(1),
+})));
+console.table([
+  {
+    process: 'node baseline',
+    elapsedP50Ms: baselineProcess.processElapsed.p50Ms.toFixed(2),
+    rssMiB: (baselineProcess.rssP50Bytes / 1024 / 1024).toFixed(2),
+    importP50Ms: '-',
+    setupP50Ms: '-',
+  },
+  {
+    process: 'FlexDoc backend import',
+    elapsedP50Ms: backendProcess.processElapsed.p50Ms.toFixed(2),
+    rssMiB: (backendProcess.rssP50Bytes / 1024 / 1024).toFixed(2),
+    importP50Ms: backendProcess.import.p50Ms.toFixed(2),
+    setupP50Ms: '-',
+  },
+  {
+    process: 'FlexDoc setup',
+    elapsedP50Ms: setupProcess.processElapsed.p50Ms.toFixed(2),
+    rssMiB: (setupProcess.rssP50Bytes / 1024 / 1024).toFixed(2),
+    importP50Ms: setupProcess.import.p50Ms.toFixed(2),
+    setupP50Ms: setupProcess.setup.p50Ms.toFixed(4),
+  },
+]);
+
+const jsonIndex = process.argv.indexOf('--json');
+if (jsonIndex >= 0) {
+  const output = process.argv[jsonIndex + 1];
+  if (!output) throw new Error('--json requires an output path');
+  fs.writeFileSync(output, `${JSON.stringify(results, null, 2)}\n`);
+  console.log(`Wrote ${output}`);
+}

--- a/scripts/performance/check-budgets.mjs
+++ b/scripts/performance/check-budgets.mjs
@@ -1,0 +1,55 @@
+import fs from 'node:fs';
+
+const input = process.argv[2] || 'performance-results.json';
+const results = JSON.parse(fs.readFileSync(input, 'utf8'));
+
+const budgets = {
+  javascript: {
+    rawBytes: 540 * 1024,
+    gzipBytes: 160 * 1024,
+    brotliBytes: 135 * 1024,
+  },
+  css: {
+    rawBytes: 41 * 1024,
+    gzipBytes: 8.2 * 1024,
+    brotliBytes: 7 * 1024,
+  },
+};
+
+const failures = [];
+for (const [asset, limits] of Object.entries(budgets)) {
+  const actual = results.bundles?.[asset];
+  if (!actual) {
+    failures.push(`${asset}: missing bundle metrics`);
+    continue;
+  }
+
+  for (const [metric, limit] of Object.entries(limits)) {
+    const value = actual[metric];
+    if (typeof value !== 'number') {
+      failures.push(`${asset}.${metric}: missing metric`);
+      continue;
+    }
+    if (value > limit) {
+      failures.push(
+        `${asset}.${metric}: ${(value / 1024).toFixed(1)} KiB exceeds ${(limit / 1024).toFixed(1)} KiB budget`,
+      );
+    }
+  }
+}
+
+if (failures.length) {
+  console.error('FlexDoc performance budget check failed:');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log('FlexDoc deterministic bundle budgets passed.');
+for (const [asset, limits] of Object.entries(budgets)) {
+  const actual = results.bundles[asset];
+  console.log(
+    `${asset}: raw ${(actual.rawBytes / 1024).toFixed(1)}/${(limits.rawBytes / 1024).toFixed(1)} KiB, ` +
+      `gzip ${(actual.gzipBytes / 1024).toFixed(1)}/${(limits.gzipBytes / 1024).toFixed(1)} KiB, ` +
+      `brotli ${(actual.brotliBytes / 1024).toFixed(1)}/${(limits.brotliBytes / 1024).toFixed(1)} KiB`,
+  );
+}


### PR DESCRIPTION
## Summary

Establish **2.9.9 Performance & Production Readiness** as the measured gate before 3.0 Runtime Intelligence. This is evidence-first: add repeatable benchmarks, remove concrete Node host overhead, and document the production cost model without inventing unstable shared-runner timing SLAs.

## What changes

- cache generated documentation host pages for Express/setupFlexDoc, Fastify, and Hono instead of serializing the OpenAPI document on every docs request
- coalesce concurrent cold page requests onto the same in-process render promise
- retain `Cache-Control: no-cache` for docs HTML while adding deterministic content-derived ETags and `If-None-Match`/304 revalidation
- prove identical content produces identical ETags across independent host instances, so replicas need no shared page cache for revalidation
- keep renderer assets version-addressed with their existing immutable one-year cache policy
- add Express path-isolation regressions proving FlexDoc registers handlers only under the configured docs prefix rather than adding global normal-route middleware
- add `npm run benchmark:performance` with generated ~100 KiB, 1 MiB, 5 MiB, and 10 MiB OpenAPI cases
- measure p50/p95/p99 serialization, warm-cache lookup, 100-request cold-cache concurrency, standalone bundle compression, clean Node process cost, backend import time/RSS, and `setupFlexDoc` setup time/RSS
- enforce deterministic standalone JS/CSS raw/gzip/Brotli budgets in CI while keeping shared-runner wall-clock timings informational
- add a permanent Performance Baseline workflow that uploads `performance-results.json`
- document production guidance for hot-path isolation, compression, caching, replica behavior, multi-pod/process-local cache behavior, detached/static deployment, and restart-based refresh when configured in-memory spec/options change
- mark published 2.9.5 accurately in the roadmap and treat 2.9.9 as source-complete pending merge/release preparation
- replace the pre-publication deterministic Go `v0.5.1` example checksum with the authoritative published Go module proxy checksum

## Measured baseline

Node 22.22.3 / Linux x64 on GitHub-hosted CI. Timing values are evidence, not hard CI budgets.

| Approx spec | Generated HTML | Uncached p50 | Uncached p95/p99 | Warm cache p99 | 100 cold concurrent requests |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 0.10 MiB | 0.10 MiB | 0.19 ms | 0.33 ms | 0.0013 ms | 0.52 ms total |
| 1.00 MiB | 1.00 MiB | 3.06 ms | 3.53 ms | 0.0005 ms | 4.75 ms total |
| 5.01 MiB | 5.01 MiB | 12.85 ms | 14.66 ms | 0.0009 ms | 17.39 ms total |
| 10.03 MiB | 10.03 MiB | 28.28 ms | 29.42 ms | 0.0004 ms | 32.16 ms total |

Canonical standalone assets:

- JavaScript: ~511.0 KiB raw / 151.0 KiB gzip / 126.6 KiB Brotli
- CSS: ~38.1 KiB raw / 7.6 KiB gzip / 6.5 KiB Brotli

Deterministic CI ceilings:

- JavaScript: 540 KiB raw / 160 KiB gzip / 135 KiB Brotli
- CSS: 41 KiB raw / 8.2 KiB gzip / 7 KiB Brotli

Clean-process measurements, p50:

- bare Node: ~20.49 ms process elapsed / ~42.76 MiB RSS
- full `@prauga/flexdoc-backend` import: ~194.44 ms process elapsed / ~163.26 ms import / ~95.89 MiB RSS
- direct setup-module + `setupFlexDoc`: ~48.30 ms process elapsed / ~27.47 ms import / **~0.278 ms setup** / ~61.23 MiB RSS

## Review findings disposition

- cached docs HTML intentionally reflects the configured integration snapshot; changing in-memory spec/options after setup requires restart until a future explicit invalidation API exists
- `If-None-Match: *` returning 304 for an existing GET representation is retained intentionally
- 2.9.5 roadmap wording is corrected to shipped
- branch history is collapsed to one meaningful commit

## Validation

- exact `npm ci`
- canonical client/standalone and backend builds
- backend integration/cache suite
- authoritative published Go `v0.5.1` checksum verification
- expanded 100 KiB → 10 MiB performance/concurrency/startup/RSS benchmark
- deterministic bundle budget enforcement
- canonical embedded-renderer parity
- Browser E2E
- Framework Coverage Completion
- `git diff --check`

## Scope boundaries

- no package/version bump in this product PR
- no new generic API-client parity work
- no timing-based CI failures; shared-runner timings remain evidence rather than fake SLAs
- no new compression layer inside adapters; application/ingress/CDN/reverse-proxy compression remains the production boundary
- no work is added to ordinary application API request paths
- host execution remains opt-in and does not introduce a background loop

FlexDoc's backend installation is part of the differentiation, so its production cost should be explicit, small, and continuously measurable.