### PR TITLE
Prepare FlexDoc 2.9.9 coordinated JavaScript release

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ No FlexDoc account, hosted dashboard, telemetry service, or runtime CDN is requi
 - **Rust:** Axum, Actix Web
 - **Elixir:** Plug, Phoenix
 
-The backend-coverage program shipped in 2.3.0, and the API Client workspace reached its first coordinated release in **2.9.0**. The source tree is now prepared as the **2.9.5 release candidate**, closing the remaining REST workspace parity gaps and adding the first capability-gated Node API-host execution path for browser-impossible cookies, certificates, and advanced auth. After this parity-hardening release, roadmap priority moves to backend-native **3.0 Runtime Intelligence**. See [`docs/api-client-roadmap.md`](./docs/api-client-roadmap.md) for the release definition and backend-native roadmap.
+The backend-coverage program shipped in 2.3.0, and the coordinated product line has now reached published **2.9.5**. The source tree is prepared as the **2.9.9 release candidate**, focused on measured production readiness: repeatable performance baselines, Node docs-page caching/revalidation, normal-route isolation, and deterministic bundle-size budgets. After 2.9.9, roadmap priority moves to backend-native **3.0 Runtime Intelligence**. See [`docs/api-client-roadmap.md`](./docs/api-client-roadmap.md) for the release definition and backend-native roadmap.
 
 ## Package family
 
 | Ecosystem | Package | Source version |
 | --- | --- | ---: |
-| npm | `@prauga/flexdoc-client` | `2.9.5` |
-| npm | `@prauga/flexdoc-backend` | `2.9.5` |
+| npm | `@prauga/flexdoc-client` | `2.9.9` |
+| npm | `@prauga/flexdoc-backend` | `2.9.9` |
 | npm | `@prauga/flexdoc-core` | `0.4.0` |
 | npm | `@prauga/flexdoc-cli` | `0.4.0` |
 | NuGet | `Prauga.FlexDoc.AspNetCore` | `0.4.1` |

--- a/docs/api-client-roadmap.md
+++ b/docs/api-client-roadmap.md
@@ -2,7 +2,7 @@
 
 FlexDoc 2.3.0 was the last coordinated product release before the API Client workspace grew through several focused development milestones. Those milestone numbers described source-development slices; they were not separate published FlexDoc package releases. The coordinated product line moved directly from published **2.3.0** to published **2.8.0** after the 2.8 source definition of done was satisfied.
 
-The current published coordinated product line is **2.9.5**. FlexDoc **2.9.9 is source-complete in this performance-readiness PR** and remains unpublished until its release preparation and release workflow complete successfully.
+The current published coordinated product line is **2.9.5**. FlexDoc **2.9.9 is source-complete and prepared as the coordinated performance-readiness release candidate**; it remains unpublished until the matching `js/v2.9.9` release workflow completes successfully.
 
 Ecosystem adapters remain independently versioned. `@prauga/flexdoc-client` and `@prauga/flexdoc-backend` carry the coordinated FlexDoc product version because they own and distribute the canonical renderer. Native adapters receive their own semantic-version increment when they package a new renderer, rather than being renamed to the product version.
 
@@ -18,7 +18,7 @@ Ecosystem adapters remain independently versioned. `@prauga/flexdoc-client` and 
 | **2.8** | Postman import into the canonical standalone workspace and coordinated product-version catch-up | shipped |
 | **2.9** | shared request executor, collection/folder runner product UI, scripting IntelliSense, grouped run history, and full request-history inspector | shipped |
 | **2.9.5** | REST workspace parity hardening plus capability-gated Node API-host execution for browser-impossible request features | shipped |
-| **2.9.9** | measured performance baseline, production delivery hardening, host-page caching/revalidation, and regression budgets before Runtime Intelligence | source complete / pending merge |
+| **2.9.9** | measured performance baseline, production delivery hardening, host-page caching/revalidation, and regression budgets before Runtime Intelligence | release candidate |
 
 Viewer expansion defaults/settings and renderer-option parity landed before the 2.8 release and are included in the 2.8 product surface.
 
@@ -74,7 +74,7 @@ The 2.9 source release candidate is complete with the following satisfied:
 - [x] future-version example manifests and the deterministic future-tag Go checksum represent the release-candidate source tree without pretending registry artifacts already exist
 - [x] the canonical standalone renderer is rebuilt and synchronized across committed adapter assets, with parity checks passing before the release candidate is proposed
 
-2.9.0 is published. 2.9.5 is also published; 2.9.9 is the current source-complete performance-readiness milestone pending merge and release preparation.
+2.9.0 and 2.9.5 are published. 2.9.9 is now prepared as the final 2.x performance-readiness release candidate.
 
 ## 2.8.0 definition of done
 
@@ -110,7 +110,7 @@ Definition of done:
 
 The architectural priority test remains unchanged: **could Scalar implement this without being installed inside the backend?** Performance work is justified here because backend installation is part of FlexDoc's differentiation; the cost of that installation must be explicit, small, and continuously measurable.
 
-## Backend-native roadmap after 2.9.5
+## Backend-native roadmap after 2.9.9
 
 FlexDoc should differentiate through information and actions available because it is installed **inside the running backend**, not by indefinitely chasing generic hosted-docs or API-client parity. The prioritization question for major roadmap work is:
 
@@ -130,6 +130,6 @@ Cloud collaboration, teams, enterprise controls, CI workflow, and additional pro
 
 ## Release interpretation
 
-Do not retroactively publish artificial 2.4.0, 2.5.0, 2.6.0, or 2.7.0 releases just to fill the numeric gap. They are recorded here as development milestones. The coordinated JavaScript product line moved through published **2.8.0**, **2.9.0**, and **2.9.5**. FlexDoc **2.9.9** is the final 2.x performance-readiness milestone before 3.0 and is not published until its dedicated release preparation and release workflow complete successfully.
+Do not retroactively publish artificial 2.4.0, 2.5.0, 2.6.0, or 2.7.0 releases just to fill the numeric gap. They are recorded here as development milestones. The coordinated JavaScript product line moved through published **2.8.0**, **2.9.0**, and **2.9.5**. FlexDoc **2.9.9** is the final 2.x performance-readiness release candidate before 3.0 and remains unpublished until the `js/v2.9.9` release workflow completes successfully.
 
 For native adapters, each package remains on its independently versioned semantic-release line while carrying the current coordinated renderer. `@prauga/flexdoc-core` remains independently versioned unless the framework-neutral engine itself changes. The CLI also remains independently versioned and consumes the coordinated client line.

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -6,8 +6,8 @@ FlexDoc uses one canonical browser renderer and thin ecosystem adapters. Every a
 
 | Artifact | Version represented by source | Release tag | Compatibility |
 | --- | --- | --- | --- |
-| `@prauga/flexdoc-client` | `2.9.5` | `js/v2.9.5` | canonical renderer; renderer contract v1 |
-| `@prauga/flexdoc-backend` | `2.9.5` | `js/v2.9.5` | matching renderer; contract v1 |
+| `@prauga/flexdoc-client` | `2.9.9` | `js/v2.9.9` | canonical renderer; renderer contract v1 |
+| `@prauga/flexdoc-backend` | `2.9.9` | `js/v2.9.9` | matching renderer; contract v1 |
 | `@prauga/flexdoc-core` | `0.4.0` | `core/v0.4.0` | framework-neutral OpenAPI engine |
 | `@prauga/flexdoc-cli` | `0.4.0` | `cli/v0.4.0` | compatible Prauga renderer |
 | `Prauga.FlexDoc.AspNetCore` | `0.4.1` | `dotnet/v0.4.1` | ASP.NET Core 8+; renderer contract v1 |
@@ -24,7 +24,7 @@ FlexDoc uses one canonical browser renderer and thin ecosystem adapters. Every a
 
 The table describes the versions encoded by the current source tree. A new source version is not considered published merely because it appears here; publication still requires its matching release workflow to complete successfully.
 
-Versions are intentionally independent across ecosystems. The FlexDoc product release line advanced directly from shipped `2.3.0` to published `2.8.0`; the published coordinated product line is `2.9.0`, and this source tree is prepared for the coordinated `2.9.5` parity-hardening release candidate. The renderer contract, not matching package numbers, is the cross-ecosystem compatibility boundary.
+Versions are intentionally independent across ecosystems. The FlexDoc product release line advanced through published `2.8.0`, `2.9.0`, and `2.9.5`; this source tree is prepared for the coordinated `2.9.9` performance-readiness release candidate. Because 2.9.9 changes Node hosting behavior and release metadata without changing the canonical renderer bytes, native adapters remain on their existing published versions and are not republished for this release. The renderer contract, not matching package numbers, is the cross-ecosystem compatibility boundary.
 
 ## Self-contained adapter artifacts
 
@@ -63,7 +63,7 @@ Before the first publish, configure a NuGet.org Trusted Publishing policy for re
 
 ## Maven Central
 
-The FlexDoc Java family carrying the 2.9.5 release-candidate renderer is coordinated at `0.7.1`:
+The current FlexDoc Java family remains coordinated at `0.7.1`. FlexDoc 2.9.9 does not change the canonical renderer bytes, so the Java artifacts do not require a republish for this release:
 
 ```text
 com.prauga.flexdoc:flexdoc-jvm:0.7.1

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,13 +4,13 @@ All runnable or compile/smoke-tested FlexDoc framework examples live here. CI ke
 
 | Example | FlexDoc package / integration |
 | --- | --- |
-| [`basic-usage`](./basic-usage) | React + `@prauga/flexdoc-client` `2.9.5` |
-| [`interactive-demo`](./interactive-demo) | React + `@prauga/flexdoc-client` `2.9.5` |
-| [`api-client`](./api-client) | Full API Client + `@prauga/flexdoc-client` `2.9.5` |
-| [`nestjs`](./nestjs) | NestJS + `@prauga/flexdoc-backend` `2.9.5` |
-| [`javascript-express`](./javascript-express) | Express + `@prauga/flexdoc-backend` `2.9.5` |
-| [`javascript-fastify`](./javascript-fastify) | Fastify + `@prauga/flexdoc-backend` `2.9.5` |
-| [`javascript-hono`](./javascript-hono) | Hono + `@prauga/flexdoc-backend` `2.9.5` |
+| [`basic-usage`](./basic-usage) | React + `@prauga/flexdoc-client` `2.9.9` |
+| [`interactive-demo`](./interactive-demo) | React + `@prauga/flexdoc-client` `2.9.9` |
+| [`api-client`](./api-client) | Full API Client + `@prauga/flexdoc-client` `2.9.9` |
+| [`nestjs`](./nestjs) | NestJS + `@prauga/flexdoc-backend` `2.9.9` |
+| [`javascript-express`](./javascript-express) | Express + `@prauga/flexdoc-backend` `2.9.9` |
+| [`javascript-fastify`](./javascript-fastify) | Fastify + `@prauga/flexdoc-backend` `2.9.9` |
+| [`javascript-hono`](./javascript-hono) | Hono + `@prauga/flexdoc-backend` `2.9.9` |
 | [`dotnet-aspnetcore`](./dotnet-aspnetcore) | `Prauga.FlexDoc.AspNetCore` `0.4.1` |
 | [`java-spring`](./java-spring) | Spring Boot + `flexdoc-spring-boot-starter` `0.7.1` |
 | [`java-quarkus`](./java-quarkus) | Quarkus/Jakarta REST + `flexdoc-jaxrs` `0.7.1` |

--- a/examples/api-client/package.json
+++ b/examples/api-client/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@prauga/flexdoc-client": "2.9.5",
+    "@prauga/flexdoc-client": "2.9.9",
     "react": "^19.2.8",
     "react-dom": "^19.2.8"
   },

--- a/examples/basic-usage/package.json
+++ b/examples/basic-usage/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@prauga/flexdoc-client": "2.9.5",
+    "@prauga/flexdoc-client": "2.9.9",
     "lucide-react": "^1.37.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8"

--- a/examples/interactive-demo/package.json
+++ b/examples/interactive-demo/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@prauga/flexdoc-client": "2.9.5",
+    "@prauga/flexdoc-client": "2.9.9",
     "lucide-react": "^1.37.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8"

--- a/examples/javascript-express/README.md
+++ b/examples/javascript-express/README.md
@@ -9,4 +9,4 @@ npm start
 
 Open `http://localhost:3000/docs`.
 
-The FlexDoc dependency is pinned to `2.9.5` and resolves directly from the published npm package. Repository CI also installs the backend package built from the current commit and boots `/docs` to verify source compatibility.
+The FlexDoc dependency is pinned to `2.9.9` and resolves directly from the published npm package. Repository CI also installs the backend package built from the current commit and boots `/docs` to verify source compatibility.

--- a/examples/javascript-express/package.json
+++ b/examples/javascript-express/package.json
@@ -6,7 +6,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@prauga/flexdoc-backend": "2.9.5",
+    "@prauga/flexdoc-backend": "2.9.9",
     "express": "^5.1.0"
   }
 }

--- a/examples/javascript-fastify/README.md
+++ b/examples/javascript-fastify/README.md
@@ -9,4 +9,4 @@ npm start
 
 Open `http://localhost:3000/docs`.
 
-The FlexDoc dependency is pinned to `2.9.5` and resolves directly from the published npm package. Repository CI also installs the backend package built from the current commit and boots the app to verify source compatibility at runtime.
+The FlexDoc dependency is pinned to `2.9.9` and resolves directly from the published npm package. Repository CI also installs the backend package built from the current commit and boots the app to verify source compatibility at runtime.

--- a/examples/javascript-fastify/package.json
+++ b/examples/javascript-fastify/package.json
@@ -6,7 +6,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@prauga/flexdoc-backend": "2.9.5",
+    "@prauga/flexdoc-backend": "2.9.9",
     "fastify": "^5.5.0"
   }
 }

--- a/examples/javascript-hono/README.md
+++ b/examples/javascript-hono/README.md
@@ -1,5 +1,5 @@
 # Hono + FlexDoc
 
-This example uses Hono `4.13.x` with the framework-neutral `setupHonoFlexDoc` helper from `@prauga/flexdoc-backend` `2.9.5`. Hono remains an optional dependency.
+This example uses Hono `4.13.x` with the framework-neutral `setupHonoFlexDoc` helper from `@prauga/flexdoc-backend` `2.9.9`. Hono remains an optional dependency.
 
 The helper registers `/docs`, `/docs/`, and the two local renderer asset routes. It accepts either an inline `spec` or a browser-visible same-origin `specUrl`.

--- a/examples/javascript-hono/package.json
+++ b/examples/javascript-hono/package.json
@@ -5,7 +5,7 @@
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "dependencies": {
-    "@prauga/flexdoc-backend": "2.9.5",
+    "@prauga/flexdoc-backend": "2.9.9",
     "hono": "^4.13.5"
   }
 }

--- a/examples/nestjs/package.json
+++ b/examples/nestjs/package.json
@@ -26,7 +26,7 @@
     "directory": "examples/nestjs"
   },
   "dependencies": {
-    "@prauga/flexdoc-backend": "2.9.5",
+    "@prauga/flexdoc-backend": "2.9.9",
     "@nestjs/common": "^12.0.1",
     "@nestjs/core": "^12.0.1",
     "@nestjs/platform-express": "^12.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
       "version": "0.1.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@prauga/flexdoc-client": "2.9.5",
+        "@prauga/flexdoc-client": "2.9.9",
         "react": "^19.2.8",
         "react-dom": "^19.2.8"
       },
@@ -76,7 +76,7 @@
       "version": "0.1.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@prauga/flexdoc-client": "2.9.5",
+        "@prauga/flexdoc-client": "2.9.9",
         "lucide-react": "^1.37.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8"
@@ -106,7 +106,7 @@
       "version": "0.1.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@prauga/flexdoc-client": "2.9.5",
+        "@prauga/flexdoc-client": "2.9.9",
         "lucide-react": "^1.37.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8"
@@ -140,7 +140,7 @@
         "@nestjs/core": "^12.0.1",
         "@nestjs/platform-express": "^12.0.1",
         "@nestjs/swagger": "^12.0.1",
-        "@prauga/flexdoc-backend": "2.9.5",
+        "@prauga/flexdoc-backend": "2.9.9",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.15.1",
         "reflect-metadata": "^0.2.2",
@@ -11957,7 +11957,7 @@
     },
     "packages/backend": {
       "name": "@prauga/flexdoc-backend",
-      "version": "2.9.5",
+      "version": "2.9.9",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "jsonwebtoken": "^9.0.2",
@@ -11995,7 +11995,7 @@
     },
     "packages/client": {
       "name": "@prauga/flexdoc-client",
-      "version": "2.9.5",
+      "version": "2.9.9",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "js-yaml": "^4.1.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prauga/flexdoc-backend",
-  "version": "2.9.5",
+  "version": "2.9.9",
   "description": "Thin self-hosted FlexDoc integrations for Express, Fastify, and NestJS",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prauga/flexdoc-client",
-  "version": "2.9.5",
+  "version": "2.9.9",
   "description": "FlexDoc's canonical self-hosted OpenAPI renderer, API explorer, and React components",
   "type": "module",
   "main": "./dist/flexdoc.umd.cjs",


### PR DESCRIPTION
## Summary

Prepare the coordinated **FlexDoc 2.9.9** JavaScript release after the performance/production-readiness milestone landed on `main`.

## Version matrix

- `@prauga/flexdoc-client` → **2.9.9**
- `@prauga/flexdoc-backend` → **2.9.9**
- `@prauga/flexdoc-core` remains **0.4.0**
- `@prauga/flexdoc-cli` remains **0.4.0**
- .NET / Java / Python / PHP / Ruby / Go / Rust / Elixir remain on their existing published versions

2.9.9 changes Node docs hosting/performance behavior but does **not** change the canonical renderer bytes or native adapter host code, so native packages do not need a republish.

## What changes

- bump client/backend manifests to 2.9.9 for the shared `js/v2.9.9` release line
- move JavaScript example dependency pins to 2.9.9
- refresh the root npm lock from the exact candidate tree
- update the package matrix, examples index, distribution/versioning docs, and roadmap release state
- document that native adapter versions intentionally remain unchanged for this release
- preserve historical 2.9.5 feature documentation for host execution and import compatibility rather than rewriting feature provenance

## Validation

The generated candidate tree passed before being collapsed into the clean commit:

- root `npm install --package-lock-only --ignore-scripts`
- exact `npm ci`
- release-matrix guard: client/backend 2.9.9; core/CLI/native versions unchanged
- core build
- client tests + build + clean-consumer package verification
- backend tests + build
- 2.9.9 performance baseline
- deterministic JS/CSS performance-budget enforcement
- `git diff --check`

The exact final PR head `f665cecb5a1bf0bb43f49b8c0836acc829b52f8c` is green across CI, Browser E2E, Performance Baseline, Framework Coverage Completion, Java, .NET, Python, PHP, and Ruby adapter workflows.

The branch contains one clean release-preparation commit and no temporary validation files.