### PR TITLE
Fix Multer audit for 3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9169,9 +9169,9 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
-      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.3.0.tgz",
+      "integrity": "sha512-cjNbm3sttszgZeGfJR124D+jFEfkXCVAsoPBmFn9X7UxmDSFHWqE2CoEj0vrmSpuAFnqWR1Szcm9QTsiHr60Xw==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "react-dom": "^19.2.8"
   },
   "overrides": {
+    "multer": "2.3.0",
     "test-exclude": "$test-exclude"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- resolve the transitive NestJS `multer` dependency to patched `2.3.0`
- regenerate the lockfile without changing the NestJS major/version line
- restore the repository-wide live `npm audit` gate to zero vulnerabilities

## Validation
Exact head: `684df7ec9785ba74078575ddfbcf4cd237b2ed62`

- one clean dependency-fix commit on the `3.3` base
- exactly `package.json` and `package-lock.json` changed
- clean `npm ci`
- `npm run audit` → 0 vulnerabilities
- focused NestJS lint/build/test-command smoke passed
- verified `node_modules/multer` resolves to `2.3.0`
- canonical CI workflow green on the exact head
- Browser E2E workflow green on the exact head

This is intentionally separate from #75 so the Java 3.3 host-execution feature remains a focused one-commit diff.